### PR TITLE
add settings

### DIFF
--- a/electron/createMenu.ts
+++ b/electron/createMenu.ts
@@ -60,7 +60,9 @@ export const createMenu = (win: BrowserWindow): void => {
           label: "Settings",
           accelerator: "Command+,",
           click() {
-            console.log("Preferences clicked");
+            const message = "Preferences clicked";
+            console.log(message);
+            win.webContents.send("open-settings", message);
           },
         },
       ],

--- a/electron/createMenu.ts
+++ b/electron/createMenu.ts
@@ -60,7 +60,7 @@ export const createMenu = (win: BrowserWindow): void => {
           label: "Settings",
           accelerator: "Command+,",
           click() {
-            const message = "Preferences clicked";
+            const message = "settings-element";
             console.log(message);
             win.webContents.send("open-settings", message);
           },

--- a/electron/createMenu.ts
+++ b/electron/createMenu.ts
@@ -52,10 +52,27 @@ export const createMenu = (win: BrowserWindow): void => {
     { role: "help", submenu: [{ role: "about" }] },
   ];
 
+  const preferences = [
+    {
+      label: "Preferences…",
+      submenu: [
+        {
+          label: "Settings",
+          accelerator: "Command+,",
+          click() {
+            console.log("Preferences clicked");
+          },
+        },
+      ],
+    },
+  ];
+
   const appMenu: MenuItemConstructorOptions = {
     label: app.name,
     submenu: [
       { role: "about" },
+      { type: "separator" },
+      ...preferences,
       { type: "separator" },
       { role: "services" },
       { type: "separator" },

--- a/electron/createMenu.ts
+++ b/electron/createMenu.ts
@@ -60,9 +60,8 @@ export const createMenu = (win: BrowserWindow): void => {
           label: "Settings",
           accelerator: "Command+,",
           click() {
-            const message = "settings-element";
-            console.log(message);
-            win.webContents.send("open-settings", message);
+            const elementName = "settings-element";
+            win.webContents.send("open-settings", elementName);
           },
         },
       ],

--- a/electron/createMenu.ts
+++ b/electron/createMenu.ts
@@ -1,4 +1,5 @@
 import {
+  app,
   BrowserWindow,
   dialog,
   Menu,
@@ -51,7 +52,22 @@ export const createMenu = (win: BrowserWindow): void => {
     { role: "help", submenu: [{ role: "about" }] },
   ];
 
-  if (process.platform === "darwin") template.unshift({ role: "appMenu" });
+  const appMenu: MenuItemConstructorOptions = {
+    label: app.name,
+    submenu: [
+      { role: "about" },
+      { type: "separator" },
+      { role: "services" },
+      { type: "separator" },
+      { role: "hide" },
+      { role: "hideOthers" },
+      { role: "unhide" },
+      { type: "separator" },
+      { role: "quit" },
+    ],
+  };
+
+  if (process.platform === "darwin") template.unshift(appMenu);
 
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -4,6 +4,7 @@ const { contextBridge, ipcRenderer } = require("electron");
 contextBridge.exposeInMainWorld("myAPI", {
   fileSaveAs: (fileData) => ipcRenderer.invoke("file-save-as", fileData),
   openByMenu: (listener) => ipcRenderer.on("open-by-menu", listener),
+  openSettings: (listener) => ipcRenderer.on("open-settings", listener),
   setupStorage: () => ipcRenderer.invoke("setup-storage"),
 });
 

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -21,6 +21,6 @@ export interface SandBox {
     listener: (_e: Event, fileData: FileData) => void
   ) => Electron.IpcRenderer;
   openSettings: (
-    listener: (_e: Event, message: string) => void
+    listener: (_e: Event, elementName: string) => void
   ) => Electron.IpcRenderer;
 }

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -16,8 +16,11 @@ export type FileData = {
 
 export interface SandBox {
   fileSaveAs: (fileData: string) => void;
+  setupStorage: () => Promise<string>;
   openByMenu: (
     listener: (_e: Event, fileData: FileData) => void
   ) => Electron.IpcRenderer;
-  setupStorage: () => Promise<string>;
+  openSettings: (
+    listener: (_e: Event, message: string) => void
+  ) => Electron.IpcRenderer;
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,4 +1,5 @@
 import "./components/app-element";
+import "./components/settings-element";
 import "./components/test-header";
 import "./components/codeEditor";
 import "./components/homeElement";

--- a/src/components/app-element.ts
+++ b/src/components/app-element.ts
@@ -5,7 +5,7 @@ const { myAPI } = window;
 @customElement("app-element")
 export class AppElement extends LitElement {
   @state()
-  private _current_page = "settings-element";
+  private _current_page = "home-element";
 
   static styles = [
     css`
@@ -18,12 +18,12 @@ export class AppElement extends LitElement {
   ];
 
   render(): TemplateResult {
-    if (this._current_page == "settings-element") {
+    if (this._current_page == "home-element") {
+      return html`<home-element></home-element>`;
+    } else {
       return html`<settings-element
         @back-to-home=${this._backToHomeListener}
       ></settings-element>`;
-    } else {
-      return html`<home-element></home-element>`;
     }
   }
 

--- a/src/components/app-element.ts
+++ b/src/components/app-element.ts
@@ -30,16 +30,16 @@ export class AppElement extends LitElement {
   async firstUpdated(): Promise<void> {
     // Give the browser a chance to paint
     await new Promise((r) => setTimeout(r, 0));
-    myAPI.openSettings((_e: Event, message: string) =>
-      this._openSettings(message)
+    myAPI.openSettings((_e: Event, elementName: string) =>
+      this._openSettings(elementName)
     );
   }
 
-  private async _openSettings(message: string): Promise<void> {
+  private async _openSettings(elementName: string): Promise<void> {
     // Give the browser a chance to paint
     await new Promise((r) => setTimeout(r, 0));
-    console.log(message);
-    this._current_page = message;
+    console.log(elementName);
+    this._current_page = elementName;
   }
 
   private _backToHomeListener(e: CustomEvent) {

--- a/src/components/app-element.ts
+++ b/src/components/app-element.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, css, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
+const { myAPI } = window;
 
 @customElement("app-element")
 export class AppElement extends LitElement {
@@ -15,5 +16,19 @@ export class AppElement extends LitElement {
 
   render(): TemplateResult {
     return html` <home-element></home-element> `;
+  }
+
+  async firstUpdated(): Promise<void> {
+    // Give the browser a chance to paint
+    await new Promise((r) => setTimeout(r, 0));
+    myAPI.openSettings((_e: Event, message: string) =>
+      this._openSettings(message)
+    );
+  }
+
+  private async _openSettings(message: string): Promise<void> {
+    // Give the browser a chance to paint
+    await new Promise((r) => setTimeout(r, 0));
+    console.log(message);
   }
 }

--- a/src/components/app-element.ts
+++ b/src/components/app-element.ts
@@ -1,9 +1,12 @@
 import { LitElement, html, css, TemplateResult } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 const { myAPI } = window;
 
 @customElement("app-element")
 export class AppElement extends LitElement {
+  @state()
+  private _current_page = "settings-element";
+
   static styles = [
     css`
       :host {
@@ -15,7 +18,13 @@ export class AppElement extends LitElement {
   ];
 
   render(): TemplateResult {
-    return html` <home-element></home-element> `;
+    if (this._current_page == "settings-element") {
+      return html`<settings-element
+        @back-to-home=${this._backToHomeListener}
+      ></settings-element>`;
+    } else {
+      return html`<home-element></home-element>`;
+    }
   }
 
   async firstUpdated(): Promise<void> {
@@ -30,5 +39,11 @@ export class AppElement extends LitElement {
     // Give the browser a chance to paint
     await new Promise((r) => setTimeout(r, 0));
     console.log(message);
+    this._current_page = message;
+  }
+
+  private _backToHomeListener(e: CustomEvent) {
+    console.log(e.detail.elementName);
+    this._current_page = e.detail.elementName;
   }
 }

--- a/src/components/settings-element.ts
+++ b/src/components/settings-element.ts
@@ -1,0 +1,37 @@
+import { LitElement, html, TemplateResult, css } from "lit";
+import { customElement } from "lit/decorators.js";
+
+@customElement("settings-element")
+export class SettingsElement extends LitElement {
+  static styles = [
+    css`
+      :host {
+        display: block;
+        width: 100%;
+        height: 100vh;
+        color: ghostwhite;
+      }
+      header {
+        display: grid;
+        grid-template-columns: 7fr 1fr;
+        align-items: center;
+        justify-content: spece-between;
+      }
+      div.close {
+        text-align: center;
+        cursor: pointer;
+      }
+    `,
+  ];
+
+  render(): TemplateResult {
+    return html`
+      <header>
+        <h1>Settings</h1>
+        <div class="close">
+          <span>X</span>
+        </div>
+      </header>
+    `;
+  }
+}

--- a/src/components/settings-element.ts
+++ b/src/components/settings-element.ts
@@ -28,10 +28,18 @@ export class SettingsElement extends LitElement {
     return html`
       <header>
         <h1>Settings</h1>
-        <div class="close">
+        <div class="close" @click=${this._dispatchBackToHome}>
           <span>X</span>
         </div>
+        <textarea></textarea>
       </header>
     `;
+  }
+
+  private _dispatchBackToHome() {
+    const options = {
+      detail: { elementName: "home-element" },
+    };
+    this.dispatchEvent(new CustomEvent("back-to-home", options));
   }
 }


### PR DESCRIPTION
- Set appMenu for macOS
- Add "Preferences... > Settings" via click and Command+,
- Send message to renderer via openSettings
- Add settings-element.ts
- Switch elements between home-element and settings-element
- Set home-element as default
- Replace message with elementName
