### PR TITLE
sticky header

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,9 @@
   <body>
     <div class="split">
       <snippet-list id="split-0"></snippet-list>
-      <app-element id="split-1"></app-element>
+      <div id="split-1">
+        <app-element></app-element>
+      </div>
     </div>
   </body>
 </html>

--- a/src/components.ts
+++ b/src/components.ts
@@ -2,5 +2,5 @@ import "./components/app-element";
 import "./components/settings-element";
 import "./components/test-header";
 import "./components/codeEditor";
-import "./components/homeElement";
+// import "./components/homeElement";
 import "./components/snippet-list";

--- a/src/components/app-element.ts
+++ b/src/components/app-element.ts
@@ -1,25 +1,39 @@
 import { LitElement, html, css, TemplateResult } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 const { myAPI } = window;
 
 @customElement("app-element")
 export class AppElement extends LitElement {
   @state()
   private _current_page = "home-element";
+  @property()
+  _textareaValue = "";
 
   static styles = [
     css`
       :host {
         display: block;
+        margin-top: 100px;
         width: 100%;
         height: 100vh;
+        position: fixed;
+        top: 0;
+        overflow: hidden;
       }
     `,
   ];
 
   render(): TemplateResult {
     if (this._current_page == "home-element") {
-      return html`<home-element></home-element>`;
+      return html`
+        <test-header textareaValue="${this._textareaValue}"></test-header>
+        <code-editor
+          code="console.log('Hello World');"
+          language="typescript"
+          @change-text="${this._changeTextListener}"
+        >
+        </code-editor>
+      `;
     } else {
       return html`<settings-element
         @back-to-home=${this._backToHomeListener}
@@ -45,5 +59,10 @@ export class AppElement extends LitElement {
   private _backToHomeListener(e: CustomEvent) {
     console.log(e.detail.elementName);
     this._current_page = e.detail.elementName;
+  }
+
+  private _changeTextListener(e: CustomEvent) {
+    console.log(e);
+    this._textareaValue = e.detail.text;
   }
 }

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -44,8 +44,9 @@ export class CodeEditor extends LitElement {
 
   static styles = css`
     :host {
+      --header-height: 100px;
       --editor-width: 100%;
-      --editor-height: 100vh;
+      --editor-height: calc(100vh - var(--header-height));
     }
     main {
       width: var(--editor-width);

--- a/src/components/settings-element.ts
+++ b/src/components/settings-element.ts
@@ -7,8 +7,8 @@ export class SettingsElement extends LitElement {
     css`
       :host {
         display: block;
-        width: 100%;
         height: 100vh;
+        margin-right: 30%;
         color: ghostwhite;
       }
       header {

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -10,14 +10,15 @@ export class SnippetList extends LitElement {
 
   constructor() {
     super();
-    this.itemCount = 10;
+    this.itemCount = 100;
   }
 
   static styles = [
     css`
       :host {
         display: block;
-        overflow-y: scroll;
+        position: sticky;
+        overflow-y: smooth;
         overflow-x: hidden;
         height: 100vh;
       }

--- a/src/components/test-header.ts
+++ b/src/components/test-header.ts
@@ -12,6 +12,11 @@ export class TestHeader extends LitElement {
   static styles = css`
     :host {
       color: ghostwhite;
+      position: fixed;
+      top: 0;
+      height: 100px;
+      width: 100%;
+      z-index: 9999;
       --textarea-width: 50%;
     }
     textarea {


### PR DESCRIPTION
- Separate test-header and code-editor in app-element. This prevents the gutter from shortening when the editor part is scrolled. home-element is not rendered, but app-element may be unnecessary.
- Add margin-right: 30% to settings-element.ts
