### PR TITLE
improve create or refresh db

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -4,6 +4,7 @@ import { app, BrowserWindow, ipcMain } from "electron";
 import { setFileSaveAs } from "./setFileSaveAs";
 import { createMenu } from "./createMenu";
 import { setupStorage } from "./setupStorage";
+import { setTimeout } from "timers/promises";
 
 const isDev = process.env.IS_DEV == "true" ? true : false;
 
@@ -54,6 +55,8 @@ app.whenReady().then(() => {
 app.once("browser-window-created", () => {
   console.log("browser-window-created");
   ipcMain.handle("setup-storage", async () => {
+    await setTimeout(5000); // wait 5 seconds for testing
+
     return setupStorage(path.resolve(os.homedir(), "fragmemo"));
   });
 });

--- a/electron/setupStorage.ts
+++ b/electron/setupStorage.ts
@@ -52,15 +52,18 @@ const createStorage = async (_path: fs.PathLike) => {
     fs.writeFile(`${_path}/.fragmemo`, "", "utf8", (err) => {
       if (err) return err;
     });
+    // create an emptry storage.json
+    fs.writeFile(`${_path}/storage.json`, "", "utf8", (err) => {
+      if (err) return err;
+    });
     // create first snippet (directory)
     const chars32 = createHash("md5").update(String(Date.now())).digest("hex");
     const chars40 = createHash("sha1").update(String(Date.now())).digest("hex");
     const snippetName = `${chars32}-${chars40}`;
     fs.mkdir(`${_path}/${snippetName}`, (err) => {
       if (err) return err;
+      createTestFile(`${_path}/${snippetName}`);
     });
-
-    createTestFile(`${_path}/${snippetName}`);
   });
 };
 

--- a/electron/setupStorage.ts
+++ b/electron/setupStorage.ts
@@ -63,6 +63,15 @@ const createStorage = async (_path: fs.PathLike) => {
     fs.mkdir(`${_path}/${snippetName}`, (err) => {
       if (err) return err;
       createTestFile(`${_path}/${snippetName}`);
+
+      const db = new StorageDB(`${_path}/storage.json`);
+      const obj = {
+        [`${snippetName}`]: {
+          fragments: ["test.ts"],
+        },
+      };
+      db.JSON(obj);
+      db.sync();
     });
   });
 };

--- a/electron/setupStorage.ts
+++ b/electron/setupStorage.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import { StorageDB, FileDoesNotExistError } from "./storageDb";
 import { scanDirectories, scanFiles } from "./scanStorage";
+import { createHash } from "crypto";
 
 export const setupStorage = (_path: fs.PathLike): string => {
   let msg = "";
@@ -51,7 +52,15 @@ const createStorage = async (_path: fs.PathLike) => {
     fs.writeFile(`${_path}/.fragmemo`, "", "utf8", (err) => {
       if (err) return err;
     });
-    createTestFile(_path);
+    // create first snippet (directory)
+    const chars32 = createHash("md5").update(String(Date.now())).digest("hex");
+    const chars40 = createHash("sha1").update(String(Date.now())).digest("hex");
+    const snippetName = `${chars32}-${chars40}`;
+    fs.mkdir(`${_path}/${snippetName}`, (err) => {
+      if (err) return err;
+    });
+
+    createTestFile(`${_path}/${snippetName}`);
   });
 };
 

--- a/electron/setupStorage.ts
+++ b/electron/setupStorage.ts
@@ -11,8 +11,7 @@ export const setupStorage = (_path: fs.PathLike): string => {
     msg = `${_path} and ${_path}/.fragmemo created.`;
   } else {
     if (canUseAsStorage(_path)) {
-      msg = `${_path} found.
-${refreshDB(_path).msg}`;
+      msg = refreshDB(_path).msg;
     } else {
       msg = `${_path} found but cannot be as storage.`;
     }
@@ -82,7 +81,9 @@ const refreshDB = (_path: fs.PathLike): { status: boolean; msg: string } => {
   try {
     const db = new StorageDB(`${_path}/storage.json`);
     refreshStorageDB(db, objsFromStorage(_path));
-    [status, msg] = [true, `${_path}/storage.json`];
+    const storageFound = `${_path} found.
+${_path}/storage.json`;
+    [status, msg] = [true, storageFound];
   } catch (error: unknown) {
     if (error instanceof FileDoesNotExistError) {
       console.error(error.name);

--- a/electron/setupStorage.ts
+++ b/electron/setupStorage.ts
@@ -7,8 +7,7 @@ export const setupStorage = (_path: fs.PathLike): string => {
   let msg = "";
 
   if (!fs.existsSync(_path)) {
-    createStorage(_path);
-    msg = `${_path} and ${_path}/.fragmemo created.`;
+    msg = createStorage(_path).msg;
   } else {
     if (canUseAsStorage(_path)) {
       msg = refreshDB(_path).msg;
@@ -44,7 +43,11 @@ function identity(num: number): number {
   });
 };
 
-const createStorage = async (_path: fs.PathLike) => {
+const createStorage = (
+  _path: fs.PathLike
+): { status: boolean; msg: string } => {
+  let [status, msg] = [false, ""];
+
   fs.mkdir(_path, (err) => {
     if (err) return err;
 
@@ -73,6 +76,8 @@ const createStorage = async (_path: fs.PathLike) => {
       db.sync();
     });
   });
+  [status, msg] = [true, `${_path} and ${_path}/.fragmemo created.`];
+  return { status, msg };
 };
 
 const refreshDB = (_path: fs.PathLike): { status: boolean; msg: string } => {

--- a/electron/setupStorage.ts
+++ b/electron/setupStorage.ts
@@ -48,22 +48,27 @@ const createStorage = (
 ): { status: boolean; msg: string } => {
   let [status, msg] = [false, ""];
 
+  const returnError = (err: NodeJS.ErrnoException) => {
+    [status, msg] = [false, err.message];
+    return err;
+  };
+
   fs.mkdir(_path, (err) => {
-    if (err) return err;
+    if (err) returnError(err);
 
     fs.writeFile(`${_path}/.fragmemo`, "", "utf8", (err) => {
-      if (err) return err;
+      if (err) returnError(err);
     });
     // create an emptry storage.json
     fs.writeFile(`${_path}/storage.json`, "", "utf8", (err) => {
-      if (err) return err;
+      if (err) returnError(err);
     });
     // create first snippet (directory)
     const chars32 = createHash("md5").update(String(Date.now())).digest("hex");
     const chars40 = createHash("sha1").update(String(Date.now())).digest("hex");
     const snippetName = `${chars32}-${chars40}`;
     fs.mkdir(`${_path}/${snippetName}`, (err) => {
-      if (err) return err;
+      if (err) returnError(err);
       createTestFile(`${_path}/${snippetName}`);
 
       const db = new StorageDB(`${_path}/storage.json`);

--- a/electron/setupStorage.ts
+++ b/electron/setupStorage.ts
@@ -12,7 +12,7 @@ export const setupStorage = (_path: fs.PathLike): string => {
   } else {
     if (canUseAsStorage(_path)) {
       msg = `${_path} found.
-${checkDB(_path).msg}`;
+${refreshDB(_path).msg}`;
     } else {
       msg = `${_path} found but cannot be as storage.`;
     }
@@ -76,15 +76,11 @@ const createStorage = async (_path: fs.PathLike) => {
   });
 };
 
-const checkDB = (_path: fs.PathLike): { status: boolean; msg: string } => {
+const refreshDB = (_path: fs.PathLike): { status: boolean; msg: string } => {
   let [status, msg] = [false, ""];
 
   try {
     const db = new StorageDB(`${_path}/storage.json`);
-    if (db.isEmpty()) {
-      [status, msg] = [true, `${_path}/storage.json is empty`];
-      return { status, msg };
-    }
     refreshStorageDB(db, objsFromStorage(_path));
     [status, msg] = [true, `${_path}/storage.json`];
   } catch (error: unknown) {


### PR DESCRIPTION
- Create first snippet (directory) in the storage
- Create an empty JSON file when create the storage
- Initialize storage.json to init the storage
- Rename checkDB to refreshDB
- Return message that found the storage from refreshDB for consistency
- Wait 5 seconds on calling setupStorage
- Quit async on createStorage and return msg
- Message for err
- Improve refreshing the DB
