### PR TITLE
Remove handler on activate in macOS

### DIFF
--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -49,6 +49,8 @@ function createWindow() {
 app.whenReady().then(() => {
   createWindow();
   app.on("activate", function () {
+    // To avoid attempting to register the same handler due to re-create a window
+    ipcMain.removeHandler("file-save-as");
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
     if (BrowserWindow.getAllWindows().length === 0) createWindow();


### PR DESCRIPTION
To avoid attempting to register the same handler due to re-create a window

On macOS, closing a window by clicking `x` button and re-opening by clicking icon, the error occurs

<img width="372" alt="スクリーンショット 2021-11-03 23 31 17" src="https://user-images.githubusercontent.com/5820754/140086071-0d4adc7e-8855-45a9-b29c-207684946de6.png">

It attempts to register a same handler, so fix to remove it before re-creating a window on activate

cf. https://github.com/responsively-org/responsively-app/pull/185
