### PR TITLE
refactor class

### DIFF
--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -52,6 +52,11 @@ class Fragment {
   public createdAt = new Date();
   public updatedAt = new Date();
 
+  // TODO: Change Partial to Required
+  constructor(data: Partial<Fragment>) {
+    Object.assign(this, data);
+  }
+
   public static schema: typeof FragmentSchema = FragmentSchema;
 }
 

--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -46,6 +46,6 @@ class Fragment {
   };
 }
 
-const realmSchema = [Snippet, Fragment];
+const realmSchema = [Snippet.schema, Fragment.schema];
 
 export { Realm, realmSchema, Snippet, Fragment };

--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -1,6 +1,6 @@
 import Realm from "realm";
 
-class Snippet extends Realm.Object {
+class Snippet {
   public _id = 0;
   public title = "";
   public fragments!: Realm.List<Fragment>;
@@ -20,7 +20,7 @@ class Snippet extends Realm.Object {
   };
 }
 
-class Fragment extends Realm.Object {
+class Fragment {
   public _id = 0;
   public title = "";
   public content = "";

--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -19,8 +19,7 @@ class Snippet {
   createdAt = new Date();
   updatedAt = new Date();
 
-  // TODO: Change Partial to Required
-  constructor(data: Partial<Snippet>) {
+  constructor(data: Required<Snippet>) {
     Object.assign(this, data);
   }
 
@@ -48,11 +47,10 @@ class Fragment {
   public _id = 0;
   public title = "";
   public content = "";
-  public snippet!: Snippet;
+  public snippet!: Snippet; // TODO: Change required to optional?
   public createdAt = new Date();
   public updatedAt = new Date();
 
-  // TODO: Change Partial to Required
   constructor(data: Partial<Fragment>) {
     Object.assign(this, data);
   }

--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -13,11 +13,16 @@ const SnippetSchema: Realm.ObjectSchema = {
 };
 
 class Snippet {
-  public _id = 0;
-  public title = "";
-  public fragments!: Fragment[];
-  public createdAt = new Date();
-  public updatedAt = new Date();
+  _id = 0;
+  title = "";
+  fragments!: Fragment[];
+  createdAt = new Date();
+  updatedAt = new Date();
+
+  // TODO: Change Partial to Required
+  constructor(data: Partial<Snippet>) {
+    Object.assign(this, data);
+  }
 
   public static schema: typeof SnippetSchema = SnippetSchema;
 }

--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -1,15 +1,5 @@
 import Realm from "realm";
 
-class Snippet {
-  public _id = 0;
-  public title = "";
-  public fragments!: Fragment[];
-  public createdAt = new Date();
-  public updatedAt = new Date();
-
-  public static schema: typeof SnippetSchema;
-}
-
 const SnippetSchema: Realm.ObjectSchema = {
   name: "Snippet",
   properties: {
@@ -22,15 +12,14 @@ const SnippetSchema: Realm.ObjectSchema = {
   primaryKey: "_id",
 };
 
-class Fragment {
+class Snippet {
   public _id = 0;
   public title = "";
-  public content = "";
-  public snippet!: Snippet;
+  public fragments!: Fragment[];
   public createdAt = new Date();
   public updatedAt = new Date();
 
-  public static schema: typeof FragmentSchema;
+  public static schema: typeof SnippetSchema = SnippetSchema;
 }
 
 const FragmentSchema: Realm.ObjectSchema = {
@@ -50,6 +39,17 @@ const FragmentSchema: Realm.ObjectSchema = {
   primaryKey: "_id",
 };
 
-const realmSchema = [SnippetSchema, FragmentSchema];
+class Fragment {
+  public _id = 0;
+  public title = "";
+  public content = "";
+  public snippet!: Snippet;
+  public createdAt = new Date();
+  public updatedAt = new Date();
+
+  public static schema: typeof FragmentSchema = FragmentSchema;
+}
+
+const realmSchema = [Snippet.schema, Fragment.schema];
 
 export { Realm, realmSchema, Snippet, Fragment };

--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -3,7 +3,7 @@ import Realm from "realm";
 class Snippet {
   public _id = 0;
   public title = "";
-  public fragments!: Realm.List<Fragment>;
+  public fragments!: Fragment[];
   public createdAt = new Date();
   public updatedAt = new Date();
 

--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -7,18 +7,20 @@ class Snippet {
   public createdAt = new Date();
   public updatedAt = new Date();
 
-  public static schema: Realm.ObjectSchema = {
-    name: "Snippet",
-    properties: {
-      _id: "int",
-      title: "string?",
-      fragments: "Fragment[]",
-      createdAt: "date",
-      updatedAt: "date",
-    },
-    primaryKey: "_id",
-  };
+  public static schema: typeof SnippetSchema;
 }
+
+const SnippetSchema: Realm.ObjectSchema = {
+  name: "Snippet",
+  properties: {
+    _id: "int",
+    title: "string?",
+    fragments: "Fragment[]",
+    createdAt: "date",
+    updatedAt: "date",
+  },
+  primaryKey: "_id",
+};
 
 class Fragment {
   public _id = 0;
@@ -28,24 +30,26 @@ class Fragment {
   public createdAt = new Date();
   public updatedAt = new Date();
 
-  public static schema: Realm.ObjectSchema = {
-    name: "Fragment",
-    properties: {
-      _id: "int",
-      title: "string?",
-      content: "string?",
-      createdAt: "date",
-      updatedAt: "date",
-      snippet: {
-        type: "linkingObjects",
-        objectType: "Snippet",
-        property: "fragments",
-      },
-    },
-    primaryKey: "_id",
-  };
+  public static schema: typeof FragmentSchema;
 }
 
-const realmSchema = [Snippet.schema, Fragment.schema];
+const FragmentSchema: Realm.ObjectSchema = {
+  name: "Fragment",
+  properties: {
+    _id: "int",
+    title: "string?",
+    content: "string?",
+    createdAt: "date",
+    updatedAt: "date",
+    snippet: {
+      type: "linkingObjects",
+      objectType: "Snippet",
+      property: "fragments",
+    },
+  },
+  primaryKey: "_id",
+};
+
+const realmSchema = [SnippetSchema, FragmentSchema];
 
 export { Realm, realmSchema, Snippet, Fragment };

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -6,6 +6,7 @@ import { setupStorage } from "./setupStorage";
 import UserSetting from "./userSetting";
 import { setTimeout } from "timers/promises";
 import DB from "./db/db";
+import { createHash } from "node:crypto";
 
 const isDev = process.env.IS_DEV == "true" ? true : false;
 const userSetting = new UserSetting(
@@ -94,7 +95,9 @@ app.once("browser-window-created", () => {
 
     db = new DB(`${app.getPath("userData")}/fragmemoDB/fragmemo.realm`);
 
-    db.createSnippet("test-snippet");
+    db.createSnippet(
+      createHash("md5").update(String(Date.now())).digest("hex")
+    );
     return setupStorage(db);
   });
 });

--- a/main-process/setupStorage.ts
+++ b/main-process/setupStorage.ts
@@ -13,7 +13,7 @@ type setupStorageResultType = {
   snippets: SnippetData;
 };
 
-const fragmentsList = (fragments: Realm.List<Fragment>) => {
+const fragmentsList = (fragments: Fragment[]) => {
   return fragments.map((fragment) => {
     return {
       _id: fragment._id,

--- a/main-process/setupStorage.ts
+++ b/main-process/setupStorage.ts
@@ -27,7 +27,7 @@ const fragmentsList = (fragments: Realm.List<Fragment>) => {
 
 export const setupStorage = (db: DB): setupStorageResultType => {
   const snippets = (
-    db.reverseSortBy("Snippet", "updatedAt") as Results<Snippet>
+    db.reverseSortBy("Snippet", "updatedAt") as unknown as Results<Snippet>
   ).map((snippet) => ({
     snippetTitle: snippet.title,
     snippetId: snippet._id,

--- a/main-process/setupStorage.ts
+++ b/main-process/setupStorage.ts
@@ -10,7 +10,7 @@ type SnippetData = {
 type setupStorageResultType = {
   status: boolean;
   msg: string;
-  snippets: SnippetData;
+  snippets: Snippet[];
 };
 
 const fragmentsList = (fragments: Fragment[]) => {
@@ -28,11 +28,13 @@ const fragmentsList = (fragments: Fragment[]) => {
 export const setupStorage = (db: DB): setupStorageResultType => {
   const snippets = (
     db.reverseSortBy("Snippet", "updatedAt") as unknown as Results<Snippet>
-  ).map((snippet) => ({
-    snippetTitle: snippet.title,
-    snippetId: snippet._id,
-    snippetUpdatedAt: snippet.updatedAt,
-    fragments: fragmentsList(snippet.fragments),
-  }));
+  ).map((snippet) => {
+    return new Snippet({
+      _id: snippet._id,
+      title: snippet.title,
+      createdAt: snippet.createdAt,
+      updatedAt: snippet.updatedAt,
+    });
+  });
   return { status: true, msg: "Snippets loaded", snippets };
 };

--- a/main-process/setupStorage.ts
+++ b/main-process/setupStorage.ts
@@ -2,11 +2,6 @@ import { Results } from "realm";
 import DB from "./db/db";
 import { Snippet, Fragment } from "./db/realm";
 
-type SnippetData = {
-  snippetTitle: Snippet["title"];
-  snippetId: Snippet["_id"];
-}[];
-
 type setupStorageResultType = {
   status: boolean;
   msg: string;

--- a/main-process/setupStorage.ts
+++ b/main-process/setupStorage.ts
@@ -15,13 +15,13 @@ type setupStorageResultType = {
 
 const fragmentsList = (fragments: Fragment[]) => {
   return fragments.map((fragment) => {
-    return {
+    return new Fragment({
       _id: fragment._id,
       title: fragment.title,
       content: fragment.content,
       createdAt: fragment.createdAt,
       updatedAt: fragment.updatedAt,
-    };
+    });
   });
 };
 
@@ -34,6 +34,7 @@ export const setupStorage = (db: DB): setupStorageResultType => {
       title: snippet.title,
       createdAt: snippet.createdAt,
       updatedAt: snippet.updatedAt,
+      fragments: fragmentsList(snippet.fragments),
     });
   });
   return { status: true, msg: "Snippets loaded", snippets };

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -45,7 +45,7 @@ export class SnippetList extends LitElement {
               description="${this.formatDatetime(snippet.updatedAt)}"
               additional-text="snippet"
               additional-text-state="Success"
-              >${snippet.title}-${snippet._id}</ui5-li
+              >${snippet.title}</ui5-li
             >`
         )}
       </ui5-list>

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -42,10 +42,10 @@ export class SnippetList extends LitElement {
         ${this.setupStorage.snippets.map(
           (snippet) =>
             html`<ui5-li
-              description="${this.formatDatetime(snippet.snippetUpdatedAt)}"
+              description="${this.formatDatetime(snippet.updatedAt)}"
               additional-text="snippet"
               additional-text-state="Success"
-              >${snippet.snippetTitle}-${snippet.snippetId}</ui5-li
+              >${snippet.title}-${snippet._id}</ui5-li
             >`
         )}
       </ui5-list>


### PR DESCRIPTION
- Do not extend Realm.Object for classes
- Use class's schema
- Change fragments field from Realm.List<Fragment> to Fragment
- Extract schema
- Set class static schema
- Map Realm Snippet data to Snippet class instance
- Map Realm Fragment data to Fragment class instance
- Change from Partial to Required on the constructor of Snippet
- Remove unused type
- Do not add ID suffix to snippet title
- Create random title of snippets for testing
