### PR TITLE
introduce electron json storage

### DIFF
--- a/__tests__/jsonStorage.ts
+++ b/__tests__/jsonStorage.ts
@@ -3,7 +3,7 @@ import path from "path";
 import os from "os";
 import {
   JsonStorage,
-  FileDoesNotExistError,
+  DatapathDoesNotExistError,
 } from "../main-process/jsonStorage";
 
 describe("JsonStorage", () => {
@@ -27,31 +27,19 @@ describe("JsonStorage", () => {
     }
   });
 
-  describe("Storage file does not exists", () => {
+  describe("datapath does not exists", () => {
     jest
       .spyOn(fs, "existsSync")
       .mockImplementationOnce(() => false) as jest.SpyInstance;
     it("should throw an error", () => {
       expect(() => {
         new JsonStorage(`${tmpDir}`);
-      }).toThrowError(FileDoesNotExistError);
+      }).toThrowError(DatapathDoesNotExistError);
     });
   });
 
   describe("new JsonStorage()", () => {
     it("should an instance of JsonStorage", () => {
-      fs.writeFileSync(
-        `${tmpDir}/window.json`,
-        JSON.stringify({
-          window: {
-            width: 1200,
-            height: 900,
-            x: 100,
-            y: 100,
-          },
-        })
-      );
-
       const jsonStorage = new JsonStorage(`${tmpDir}`);
       expect(jsonStorage).toBeInstanceOf(JsonStorage);
     });

--- a/__tests__/jsonStorage.ts
+++ b/__tests__/jsonStorage.ts
@@ -1,0 +1,50 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import JsonStorage from "../main-process/jsonStorage";
+
+describe("JsonStorage", () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    try {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "test-"));
+    } catch (err) {
+      throw new Error("Could not create tmp dir");
+    }
+  });
+  afterEach(() => {
+    try {
+      if (tmpDir) {
+        fs.rmSync(tmpDir, { recursive: true });
+      }
+    } catch (e) {
+      console.error(
+        `An error has occurred while removing the temp folder at ${tmpDir}. Please remove it manually. Error: ${e}`
+      );
+    }
+  });
+
+  describe("new JsonStorage()", () => {
+    it("should an instance of JsonStorage", () => {
+      fs.writeFileSync(
+        `${tmpDir}/window.json`,
+        JSON.stringify({
+          window: {
+            width: 1200,
+            height: 900,
+            x: 100,
+            y: 100,
+          },
+        })
+      );
+
+      const jsonStorage = new JsonStorage(`${tmpDir}`);
+      expect(jsonStorage).toBeInstanceOf(JsonStorage);
+    });
+  });
+
+  // TODO: test settings file is empty
+  xdescribe("Settings file is empty", () => {
+    it("", () => {});
+  });
+});

--- a/__tests__/jsonStorage.ts
+++ b/__tests__/jsonStorage.ts
@@ -1,7 +1,10 @@
 import fs from "fs";
 import path from "path";
 import os from "os";
-import JsonStorage from "../main-process/jsonStorage";
+import {
+  JsonStorage,
+  FileDoesNotExistError,
+} from "../main-process/jsonStorage";
 
 describe("JsonStorage", () => {
   let tmpDir: string;
@@ -24,6 +27,17 @@ describe("JsonStorage", () => {
     }
   });
 
+  describe("Storage file does not exists", () => {
+    jest
+      .spyOn(fs, "existsSync")
+      .mockImplementationOnce(() => false) as jest.SpyInstance;
+    it("should throw an error", () => {
+      expect(() => {
+        new JsonStorage(`${tmpDir}`);
+      }).toThrowError(FileDoesNotExistError);
+    });
+  });
+
   describe("new JsonStorage()", () => {
     it("should an instance of JsonStorage", () => {
       fs.writeFileSync(
@@ -41,10 +55,5 @@ describe("JsonStorage", () => {
       const jsonStorage = new JsonStorage(`${tmpDir}`);
       expect(jsonStorage).toBeInstanceOf(JsonStorage);
     });
-  });
-
-  // TODO: test settings file is empty
-  xdescribe("Settings file is empty", () => {
-    it("", () => {});
   });
 });

--- a/main-process/jsonStorage.ts
+++ b/main-process/jsonStorage.ts
@@ -1,0 +1,12 @@
+import storage from "electron-json-storage";
+
+export default class JsonStorage {
+  lib: typeof storage;
+  datapath: string;
+
+  constructor(datapath: string) {
+    this.lib = storage;
+    this.lib.setDataPath(datapath);
+    this.datapath = this.lib.getDataPath();
+  }
+}

--- a/main-process/jsonStorage.ts
+++ b/main-process/jsonStorage.ts
@@ -1,30 +1,29 @@
 import fs from "fs";
 import storage from "electron-json-storage";
-import os from "os";
 
 export default class JsonStorage {
   lib: typeof storage;
   datapath: string;
 
   constructor(datapath: string) {
-    this.doesFileExist(datapath);
+    this.doesDatapathExist(datapath);
     this.lib = storage;
     this.lib.setDataPath(datapath);
     this.datapath = this.lib.getDataPath();
   }
 
-  doesFileExist(filePath: fs.PathLike): void {
+  doesDatapathExist(filePath: fs.PathLike): void {
     if (!fs.existsSync(filePath)) {
-      throw new FileDoesNotExistError(`${filePath} does not exist`);
+      throw new DatapathDoesNotExistError(`${filePath} does not exist`);
     }
   }
 }
 
-class FileDoesNotExistError extends Error {
+class DatapathDoesNotExistError extends Error {
   constructor(e?: string) {
     super(e);
     this.name = new.target.name;
   }
 }
 
-export { JsonStorage, FileDoesNotExistError };
+export { JsonStorage, DatapathDoesNotExistError };

--- a/main-process/jsonStorage.ts
+++ b/main-process/jsonStorage.ts
@@ -1,12 +1,30 @@
+import fs from "fs";
 import storage from "electron-json-storage";
+import os from "os";
 
 export default class JsonStorage {
   lib: typeof storage;
   datapath: string;
 
   constructor(datapath: string) {
+    this.doesFileExist(datapath);
     this.lib = storage;
     this.lib.setDataPath(datapath);
     this.datapath = this.lib.getDataPath();
   }
+
+  doesFileExist(filePath: fs.PathLike): void {
+    if (!fs.existsSync(filePath)) {
+      throw new FileDoesNotExistError(`${filePath} does not exist`);
+    }
+  }
 }
+
+class FileDoesNotExistError extends Error {
+  constructor(e?: string) {
+    super(e);
+    this.name = new.target.name;
+  }
+}
+
+export { JsonStorage, FileDoesNotExistError };

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -13,7 +13,7 @@ const isDev = process.env.IS_DEV == "true" ? true : false;
 let db: DB;
 let jsonStorage: JsonStorage;
 
-function windowSettingsReady(): void {
+function createWindowSettings(): void {
   const datapath = `${app.getPath("userData")}/fragmemoSettings/restore`;
 
   try {
@@ -107,7 +107,7 @@ function createWindow() {
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
   (async () => {
-    windowSettingsReady();
+    createWindowSettings();
     await setTimeout(100);
     createWindow();
     app.on("activate", function () {

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -13,7 +13,7 @@ const isDev = process.env.IS_DEV == "true" ? true : false;
 let db: DB;
 let jsonStorage: JsonStorage;
 
-function createWindowSettings(): void {
+async function createWindowSettings(): Promise<void> {
   const datapath = `${app.getPath("userData")}/fragmemoSettings/restore`;
 
   try {
@@ -36,6 +36,11 @@ function createWindowSettings(): void {
     } else {
       throw error;
     }
+  } finally {
+    // electron-json-storage set() is async, so we need to wait for it to finish
+    // Check that the writes were actually successful after a little bit
+    //github.dev/electron-userland/electron-json-storage/blob/df4edce1e643e7343d962721fe2eacfeda094870/lib/storage.js#L419-L439
+    await setTimeout(100);
   }
 }
 
@@ -107,8 +112,7 @@ function createWindow() {
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
   (async () => {
-    createWindowSettings();
-    await setTimeout(100);
+    await createWindowSettings();
     createWindow();
     app.on("activate", function () {
       // To avoid attempting to register the same handler due to re-create a window

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -14,27 +14,25 @@ let db: DB;
 let jsonStorage: JsonStorage;
 
 function windowSettingsReady(): void {
+  const datapath = `${app.getPath("userData")}/fragmemoSettings/restore`;
+
   try {
-    jsonStorage = new JsonStorage(
-      path.resolve(`${app.getPath("userData")}/fragmemoSettings/restore`)
-    );
+    jsonStorage = new JsonStorage(path.resolve(datapath));
   } catch (error) {
     if (error instanceof DatapathDoesNotExistError) {
-      fs.mkdirSync(
-        path.resolve(`${app.getPath("userData")}/fragmemoSettings/restore`),
-        { recursive: true }
-      );
-      const defaultWindowSettings = {
-        window: { width: 800, height: 600, x: 0, y: 0 },
-      };
-      jsonStorage = new JsonStorage(
-        path.resolve(`${app.getPath("userData")}/fragmemoSettings/restore`)
-      );
-      jsonStorage.lib.set("window", defaultWindowSettings, function (err) {
-        if (err) {
-          console.log(err);
+      fs.mkdirSync(path.resolve(datapath), { recursive: true });
+      jsonStorage = new JsonStorage(path.resolve(datapath));
+      jsonStorage.lib.set(
+        "window",
+        {
+          window: { width: 800, height: 600, x: 0, y: 0 },
+        },
+        function (err) {
+          if (err) {
+            throw err;
+          }
         }
-      });
+      );
     } else {
       throw error;
     }

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -127,7 +127,7 @@ app.whenReady().then(() => {
 app.once("browser-window-created", () => {
   console.log("browser-window-created");
   ipcMain.handle("setup-storage", async () => {
-    await setTimeout(5000); // wait 5 seconds for testing
+    await setTimeout(1000); // wait 1 seconds for testing
 
     db = new DB(`${app.getPath("userData")}/fragmemoDB/fragmemo.realm`);
 

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -41,7 +41,7 @@ function windowSettingsReady(): void {
   }
 }
 
-async function createWindow() {
+function createWindow() {
   type settingsDataType = {
     window: {
       width: number;
@@ -50,9 +50,6 @@ async function createWindow() {
       y: number;
     };
   };
-
-  windowSettingsReady();
-  await setTimeout(100); // wait for the windowSettingsReady to finish
 
   const data = <settingsDataType>jsonStorage.lib.getSync("window");
   const { width, height, x, y } = data.window;
@@ -111,13 +108,19 @@ async function createWindow() {
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
 app.whenReady().then(() => {
-  createWindow();
-  app.on("activate", function () {
-    // To avoid attempting to register the same handler due to re-create a window
-    ipcMain.removeHandler("file-save-as");
-    // On macOS it's common to re-create a window in the app when the
-    // dock icon is clicked and there are no other windows open.
-    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  (async () => {
+    windowSettingsReady();
+    await setTimeout(100);
+    createWindow();
+    app.on("activate", function () {
+      // To avoid attempting to register the same handler due to re-create a window
+      ipcMain.removeHandler("file-save-as");
+      // On macOS it's common to re-create a window in the app when the
+      // dock icon is clicked and there are no other windows open.
+      if (BrowserWindow.getAllWindows().length === 0) createWindow();
+    });
+  })().catch((err) => {
+    console.info(err);
   });
 });
 

--- a/main-process/tsconfig.json
+++ b/main-process/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "module": "CommonJS",
     "outDir": "../build",
-    "allowJs": true
+    "allowJs": true,
+    "baseUrl": "./",
+    "paths": {
+      "electron-json-storage": ["../src/@types/electron-json-storage"]
+    }
   },
   "include": ["./**/*.ts", "./**/*.js"]
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@swc/core": "1.2.112",
     "@swc/jest": "^0.2.9",
+    "@types/electron-json-storage": "^4.5.0",
     "@types/jest": "^27.0.3",
     "@types/node": "^16.11.10",
     "@typescript-eslint/eslint-plugin": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "cross-env": "^7.0.3",
     "electron": "^16.0.2",
     "electron-builder": "^22.14.5",
+    "electron-json-storage": "^4.5.0",
     "eslint": "^8.3.0",
     "eslint-config-prettier": "^8.3.0",
     "jest": "^27.3.1",

--- a/src/@types/electron-json-storage/index.d.ts
+++ b/src/@types/electron-json-storage/index.d.ts
@@ -1,0 +1,82 @@
+/* eslint-disable */
+// @ts-nocheck
+
+// Type definitions for electron-json-storage 4.5
+// Project: https://github.com/electron-userland/electron-json-storage
+// Definitions by: Sam Saint-Pettersen <https://github.com/stpettersens>,
+//                 nrlquaker <https://github.com/nrlquaker>,
+//                 John Woodruff <https://github.com/jbw91>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.2
+
+export interface DataOptions {
+  dataPath: string;
+}
+export function getDefaultDataPath(): string;
+export function setDataPath(directory?: string): void;
+export function getDataPath(): string;
+export function get(
+  key: string,
+  callback: (error: any, data: object) => void
+): void;
+export function get(
+  key: string,
+  options: DataOptions,
+  callback: (error: any, data: object) => void
+): void;
+export function getSync(key: string, options?: DataOptions): object;
+export function getMany(
+  keys: ReadonlyArray<string>,
+  callback: (error: any, data: object) => void
+): void;
+export function getMany(
+  keys: ReadonlyArray<string>,
+  options: DataOptions,
+  callback: (error: any, data: object) => void
+): void;
+export function getAll(callback: (error: any, data: object) => void): void;
+export function getAll(
+  options: DataOptions,
+  callback: (error: any, data: object) => void
+): void;
+export function set(
+  key: string,
+  json: object,
+  callback: (error: any) => void
+): void;
+// overwrite default definition
+// dataPath can be optional because the default value sets to dataPath
+// https://github.com/electron-userland/electron-json-storage/pull/94
+// prettyPrinting can be specified alone
+// https://github.com/electron-userland/electron-json-storage/blob/7f3c9377fabc6d3fe30c241db7bf04903c306d96/tests/storage.spec.js#L803
+export function set(
+  key: string,
+  json: object,
+  options: { dataPath?: string; validate?: string; prettyPrinting?: boolean },
+  callback: (error: any) => void
+): void;
+export function has(
+  key: string,
+  callback: (error: any, hasKey: boolean) => void
+): void;
+export function has(
+  key: string,
+  options: DataOptions,
+  callback: (error: any, hasKey: boolean) => void
+): void;
+export function keys(callback: (error: any, keys: string[]) => void): void;
+export function keys(
+  options: DataOptions,
+  callback: (error: any, keys: string[]) => void
+): void;
+export function remove(key: string, callback: (error: any) => void): void;
+export function remove(
+  key: string,
+  options: DataOptions,
+  callback: (error: any) => void
+): void;
+export function clear(callback: (error: any) => void): void;
+export function clear(
+  options: DataOptions,
+  callback: (error: any) => void
+): void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1035,6 +1035,11 @@
   dependencies:
     "@types/ms" "*"
 
+"@types/electron-json-storage@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@types/electron-json-storage/-/electron-json-storage-4.5.0.tgz#c0ca8fd6a694c5a0fa28ffccd5cafc8f538f2b61"
+  integrity sha512-wzDtkJHEENo4yLARfPjdYD6Foa7IORXFiNYLacZ6lJThkrGUWh5vlSSMu925ov5zv8tQHtajn2O7BpHcBtqU3g==
+
 "@types/fs-extra@^9.0.11":
   version "9.0.13"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,6 +1538,13 @@ async@0.9.x:
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
 
+async@^2.0.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.3.tgz#d72625e2344a3656e3a3ad4fa749fa83299d82ff"
+  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
+  dependencies:
+    lodash "^4.17.14"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -2425,6 +2432,18 @@ electron-builder@^22.14.5:
     update-notifier "^5.1.0"
     yargs "^17.0.1"
 
+electron-json-storage@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/electron-json-storage/-/electron-json-storage-4.5.0.tgz#7a34cf34c373f94b181a042c32ea9bf4a3b65fb7"
+  integrity sha512-ML6Um4tZbJv938EbxvMJwzLA+v/wfWwEP+AXNum1zQF9RUFJ/SrRtIjGm9eFTFxURxn81r3ggdovuQikyF/m0Q==
+  dependencies:
+    async "^2.0.0"
+    lockfile "^1.0.4"
+    lodash "^4.0.1"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.1"
+    write-file-atomic "^2.4.2"
+
 electron-osx-sign@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/electron-osx-sign/-/electron-osx-sign-0.5.0.tgz#fc258c5e896859904bbe3d01da06902c04b51c3a"
@@ -3251,7 +3270,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
@@ -4299,6 +4318,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lockfile@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
+  integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
+  dependencies:
+    signal-exit "^3.0.2"
+
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
@@ -4309,7 +4335,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.0.1, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -4458,7 +4484,7 @@ mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
-mkdirp@^0.5.4:
+mkdirp@^0.5.1, mkdirp@^0.5.4:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -5121,6 +5147,13 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rimraf@^2.5.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
@@ -6049,6 +6082,15 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+write-file-atomic@^2.4.2:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
 
 write-file-atomic@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
- Install electron-json-storage
- Install types/electron-json-storage
- Overwrite type definitions for electron-json-storage
- Use JsonStorage instead of UseSetting
- Add __tests__/jsonStorage.ts with simple tests
- Throw error when datapath does not exist
- Refactor jsonStorage and its test
- Create fragmemoSettings/restore/window.json on createWindow() if it does not exist
- Wait before createWindow() is called
- Wait 1 seconds before DB setup
- Refactor windowSettingsReady()
- Rename windowSettingsReady() to createWindowSettings()
- Wait 100 ms in createWindowSettings()
