### PR TITLE
refactoring fragment tab

### DIFF
--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -24,6 +24,11 @@ export class EditorElement extends LitElement {
       <header>
         <test-header textareaValue="${this._textareaValue}"></test-header>
         <fragment-tab-list></fragment-tab-list>
+        <code-editor
+          code="const num: number = 1;"
+          language="typescript"
+        ></code-editor
+        >;
       </header>
     `;
   }

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -12,6 +12,15 @@ export class FragmentTabList extends LitElement {
     }
   `;
 
+  settingsTemplate(): TemplateResult {
+    return html`
+      <sl-tab slot="nav" panel="tab-settings" closable>Tab settings</sl-tab>
+      <sl-tab-panel name="tab-settings">
+        <settings-element></settings-element>
+      </sl-tab-panel>
+    `;
+  }
+
   render(): TemplateResult {
     return html`
       <sl-tab-group class="tabs-closable">
@@ -23,11 +32,7 @@ export class FragmentTabList extends LitElement {
             </sl-tab-panel>
           `;
         })}
-
-        <sl-tab slot="nav" panel="tab-settings" closable>Tab settings</sl-tab>
-        <sl-tab-panel name="tab-settings">
-          <settings-element></settings-element>
-        </sl-tab-panel>
+        ${this.settingsTemplate()}
       </sl-tab-group>
     `;
   }

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -45,7 +45,6 @@ export class FragmentTabList extends LitElement {
   firstUpdated() {
     console.log("FragmentTabList firstUpdated");
     console.info(this.tabs);
-    this.tabs[1].active = true;
 
     this.tabGroup.addEventListener("sl-close", async (event) => {
       const tab = event.target as HTMLElement;
@@ -55,9 +54,15 @@ export class FragmentTabList extends LitElement {
 
       // Show the previous tab if the tab is currently active
       if (tab.active) {
-        this.tabGroup.show(
-          tab.previousElementSibling?.previousElementSibling.panel
-        );
+        const previousTab = tab.previousElementSibling
+          ?.previousElementSibling as HTMLElement;
+        const nextTab = tab.nextElementSibling
+          ?.nextElementSibling as HTMLElement;
+        if (previousTab) {
+          this.tabGroup.show(previousTab.panel);
+        } else {
+          this.tabGroup.show(nextTab.panel);
+        }
       }
 
       // Remove the tab + panel

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -5,7 +5,7 @@ import { customElement, query, queryAll } from "lit/decorators.js";
 
 @customElement("fragment-tab-list")
 export class FragmentTabList extends LitElement {
-  @query(".tabs-closable") tabGroup!: HTMLElement;
+  @query("sl-tab-group") tabGroup!: HTMLElement;
   @queryAll("sl-tab[panel^='tab-']") tabs: Array<HTMLElement>;
 
   static styles = css`

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -25,12 +25,12 @@ export class FragmentTabList extends LitElement {
   render(): TemplateResult {
     return html`
       <sl-tab-group class="tabs-closable">
-        ${this.range(1, 10).map((num, i) => {
+        ${this.range(1, 10).map((num, _) => {
           return html`
-            <sl-tab slot="nav" panel="tab-${i}" closable>Tab ${i}</sl-tab>
-            <sl-tab-panel name="tab-${i}">
+            <sl-tab slot="nav" panel="tab-${num}" closable>Tab ${num}</sl-tab>
+            <sl-tab-panel name="tab-${num}">
               <code-editor
-                code="const num: number = ${i};"
+                code="const num: number = ${num};"
                 language="typescript"
               >
               </code-editor>

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -1,11 +1,12 @@
 // @ts-nocheck
 
 import { LitElement, html, css, TemplateResult } from "lit";
-import { customElement, query } from "lit/decorators.js";
+import { customElement, query, queryAll } from "lit/decorators.js";
 
 @customElement("fragment-tab-list")
 export class FragmentTabList extends LitElement {
   @query(".tabs-closable") tabGroup!: HTMLElement;
+  @queryAll("sl-tab[panel^='tab-']") tabs: Array<HTMLElement>;
 
   static styles = css`
     :host {
@@ -28,7 +29,11 @@ export class FragmentTabList extends LitElement {
           return html`
             <sl-tab slot="nav" panel="tab-${i}" closable>Tab ${i}</sl-tab>
             <sl-tab-panel name="tab-${i}">
-              <code-editor code="" language="typescript"> </code-editor>
+              <code-editor
+                code="const num: number = ${i};"
+                language="typescript"
+              >
+              </code-editor>
             </sl-tab-panel>
           `;
         })}
@@ -39,6 +44,8 @@ export class FragmentTabList extends LitElement {
 
   firstUpdated() {
     console.log("FragmentTabList firstUpdated");
+    console.info(this.tabs);
+    this.tabs[1].active = true;
 
     this.tabGroup.addEventListener("sl-close", async (event) => {
       const tab = event.target as HTMLElement;
@@ -56,6 +63,10 @@ export class FragmentTabList extends LitElement {
       // Remove the tab + panel
       tab.remove();
       panel.remove();
+    });
+
+    this.tabGroup.addEventListener("sl-tab-show", (event) => {
+      console.info("Tab show", event);
     });
   }
 

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -28,13 +28,6 @@ export class FragmentTabList extends LitElement {
         ${this.range(1, 10).map((num, _) => {
           return html`
             <sl-tab slot="nav" panel="tab-${num}" closable>Tab ${num}</sl-tab>
-            <sl-tab-panel name="tab-${num}">
-              <code-editor
-                code="const num: number = ${num};"
-                language="typescript"
-              >
-              </code-editor>
-            </sl-tab-panel>
           `;
         })}
         ${this.settingsTemplate()}

--- a/src/controllers/snippet-controller.ts
+++ b/src/controllers/snippet-controller.ts
@@ -27,6 +27,11 @@ export class SnippetController implements ReactiveController {
 
   private _selectSnippetListener = (e: CustomEvent): void => {
     this.selectedSnippet = JSON.parse(e.detail.message);
+    console.info(
+      this.constructor.name,
+      "has selected snippet",
+      this.selectedSnippet
+    );
     this.host.requestUpdate();
   };
 


### PR DESCRIPTION
- Extract settingsTemplate()
- Active the second tab for testing
- Get tabGroup from sl-tab-group
- Use num starts from 1
- Show next panel when the panel is closed with the active tab
- Move code-editor out of fragment-tab-list to editor-element
- Use console.info on selecting a snippet
