### PR TITLE
fragment title element

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -7,3 +7,4 @@ import "./components/snippet-list";
 import "./components/search-item";
 import "./components/toast-element";
 import "./components/fragment-tab-list";
+import "./components/fragment-title";

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -4,12 +4,8 @@ import { LitElement, html, css, TemplateResult } from "lit";
 import { customElement, query, queryAll } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 
-import { SnippetController } from "../controllers/snippet-controller";
-
 @customElement("fragment-tab-list")
 export class FragmentTabList extends LitElement {
-  private snippet = new SnippetController(this);
-
   @query("sl-tab-group") tabGroup!: HTMLElement;
   @queryAll("sl-tab[panel^='tab-']") tabs: Array<HTMLElement>;
 
@@ -56,14 +52,7 @@ export class FragmentTabList extends LitElement {
           (num, _) => {
             return html`
               <sl-tab slot="nav" closable panel="tab-${num}">
-                <input
-                  type="text"
-                  class="is-editable"
-                  value="${this.snippet.selectedSnippet.title}"
-                  placeholder="untitled"
-                  readonly
-                  @dblclick="${this.onDblclickHandler}"
-                />
+                <fragment-title></fragment-title>
               </sl-tab>
             `;
           }
@@ -71,11 +60,6 @@ export class FragmentTabList extends LitElement {
         ${this.settingsTemplate()}
       </sl-tab-group>
     `;
-  }
-
-  onDblclickHandler(e) {
-    e.currentTarget.removeAttribute("readonly");
-    console.log("dblclicked!");
   }
 
   firstUpdated() {

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -55,6 +55,8 @@ export class FragmentTabList extends LitElement {
                   class="is-editable"
                   value="${this.snippet.selectedSnippet.title}"
                   placeholder="untitled"
+                  readonly
+                  @dblclick="${this.onDblclickHandler}"
                 />
               </sl-tab>
             `;
@@ -63,6 +65,11 @@ export class FragmentTabList extends LitElement {
         ${this.settingsTemplate()}
       </sl-tab-group>
     `;
+  }
+
+  onDblclickHandler(e) {
+    e.currentTarget.removeAttribute("readonly");
+    console.log("dblclicked!");
   }
 
   firstUpdated() {

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -28,12 +28,18 @@ export class FragmentTabList extends LitElement {
     sl-tab > input:not([readonly]):focus-visible {
       outline: var(--sl-color-primary-600) solid 1px;
     }
+    .tab-settings {
+      user-select: none;
+    }
+    .tab-settings > input {
+      pointer-events: none;
+    }
   `;
 
   settingsTemplate(): TemplateResult {
     return html`
-      <sl-tab slot="nav" panel="tab-settings" closable
-        ><input type="text" class="is-editable" value="Tab settings" readonly
+      <sl-tab slot="nav" panel="tab-settings" closable class="tab-settings"
+        ><input type="text" value="Settings" readonly
       /></sl-tab>
       <sl-tab-panel name="tab-settings">
         <settings-element></settings-element>

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -30,7 +30,6 @@ export class FragmentTitle extends LitElement {
     return html`
       <input
         type="text"
-        class="is-editable"
         value="${this.snippet.selectedSnippet.title}"
         placeholder="untitled"
         readonly

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -35,6 +35,8 @@ export class FragmentTitle extends LitElement {
         placeholder="untitled"
         readonly
         @dblclick="${this._enableEdit}"
+        @keydown="${this._disableEditOnEnter}"
+        @blur="${this._disableEditOnBlur}"
       />
     `;
   }
@@ -43,5 +45,17 @@ export class FragmentTitle extends LitElement {
     const target = <HTMLInputElement>e.currentTarget;
     target.removeAttribute("readonly");
     target.select();
+  }
+
+  private _disableEditOnEnter(e: KeyboardEvent) {
+    const target = <HTMLInputElement>e.currentTarget;
+    if (e.key === "Enter" && e.isComposing === false) {
+      target.setAttribute("readonly", "true");
+    }
+  }
+
+  private _disableEditOnBlur(e: FocusEvent) {
+    const target = <HTMLInputElement>e.currentTarget;
+    target.setAttribute("readonly", "true");
   }
 }

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -1,0 +1,47 @@
+import { LitElement, html, TemplateResult, css } from "lit";
+import { customElement } from "lit/decorators.js";
+import { SnippetController } from "../controllers/snippet-controller";
+
+@customElement("fragment-title")
+export class FragmentTitle extends LitElement {
+  private snippet = new SnippetController(this);
+
+  static styles = [
+    css`
+      :host {
+      }
+
+      input {
+        background-color: transparent;
+        color: white;
+        border: none;
+        text-align: center;
+      }
+      input[readonly] {
+        outline: none;
+      }
+      input:not([readonly]):focus-visible {
+        outline: var(--sl-color-primary-600) solid 1px;
+      }
+    `,
+  ];
+
+  render(): TemplateResult {
+    return html`
+      <input
+        type="text"
+        class="is-editable"
+        value="${this.snippet.selectedSnippet.title}"
+        placeholder="untitled"
+        readonly
+        @dblclick="${this._enableEdit}"
+      />
+    `;
+  }
+
+  private _enableEdit(e: MouseEvent) {
+    const target = <HTMLInputElement>e.currentTarget;
+    target.removeAttribute("readonly");
+    target.select();
+  }
+}

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -1,9 +1,13 @@
 import { LitElement, html, TemplateResult, css } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, property, query } from "lit/decorators.js";
 import { SnippetController } from "../controllers/snippet-controller";
 
 @customElement("fragment-title")
 export class FragmentTitle extends LitElement {
+  @query("input") private inputElement!: HTMLInputElement;
+  @property({ type: String })
+  initialValue!: string;
+
   private snippet = new SnippetController(this);
 
   static styles = [
@@ -42,14 +46,21 @@ export class FragmentTitle extends LitElement {
 
   private _enableEdit(e: MouseEvent) {
     const target = <HTMLInputElement>e.currentTarget;
+    this.initialValue = this.inputElement.value;
     target.removeAttribute("readonly");
     target.select();
   }
 
   private _disableEditOnEnter(e: KeyboardEvent) {
     const target = <HTMLInputElement>e.currentTarget;
-    if (e.key === "Enter" && e.isComposing === false) {
-      target.setAttribute("readonly", "true");
+    if (!e.isComposing) {
+      if (e.key === "Enter") {
+        target.setAttribute("readonly", "true");
+      }
+      if (e.key === "Escape") {
+        target.value = this.initialValue;
+        target.setAttribute("readonly", "true");
+      }
     }
   }
 


### PR DESCRIPTION
- Remove readonly attribute on dblclick
- Disable selecting text on Settings tab
- Create FragmentTitle element
- Set readonly to the input on enter or blur
- Remove unused CSS class
- Cancel input by esc key
