### PR TITLE
switch tabs via shortcuts

### DIFF
--- a/main-process/createMenu.ts
+++ b/main-process/createMenu.ts
@@ -8,6 +8,28 @@ import {
 import * as fs from "fs";
 
 export const createMenu = (win: BrowserWindow): void => {
+  const switchTab = [
+    {
+      label: "Switch Tab",
+      submenu: [
+        {
+          label: "Next Tab",
+          accelerator: "CmdOrCtrl+Shift+]",
+          click: async () => {
+            console.log("Next Tab");
+          },
+        },
+        {
+          label: "Previous Tab",
+          accelerator: "CmdOrCtrl+Shift+[",
+          click: async () => {
+            console.log("Previous Tab");
+          },
+        },
+      ],
+    },
+  ];
+
   const template: MenuItemConstructorOptions[] = [
     {
       label: "File",
@@ -63,6 +85,7 @@ export const createMenu = (win: BrowserWindow): void => {
     },
     { role: "editMenu" },
     { role: "viewMenu" },
+    { label: "Go", submenu: [...switchTab] },
     { role: "windowMenu" },
     { role: "help", submenu: [{ role: "about" }] },
   ];

--- a/main-process/createMenu.ts
+++ b/main-process/createMenu.ts
@@ -16,14 +16,14 @@ export const createMenu = (win: BrowserWindow): void => {
           label: "Next Tab",
           accelerator: "CmdOrCtrl+Shift+]",
           click: async () => {
-            console.log("Next Tab");
+            win.webContents.send("next-tab");
           },
         },
         {
           label: "Previous Tab",
           accelerator: "CmdOrCtrl+Shift+[",
           click: async () => {
-            console.log("Previous Tab");
+            win.webContents.send("previous-tab");
           },
         },
       ],

--- a/main-process/preload.js
+++ b/main-process/preload.js
@@ -6,6 +6,8 @@ contextBridge.exposeInMainWorld("myAPI", {
   openByMenu: (listener) => ipcRenderer.on("open-by-menu", listener),
   openSettings: (listener) => ipcRenderer.on("open-settings", listener),
   saveFragment: (listener) => ipcRenderer.on("save-fragment", listener),
+  nextTab: (listener) => ipcRenderer.on("next-tab", listener),
+  previousTab: (listener) => ipcRenderer.on("previous-tab", listener),
   newSnippet: (listener) => ipcRenderer.on("new-snippet", listener),
   createSnippet: () => ipcRenderer.invoke("create-snippet"),
   setupStorage: () => ipcRenderer.invoke("setup-storage"),

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -68,6 +68,7 @@ export class FragmentTabList extends LitElement {
     if (this.currentTabIndex > this.lastTabIndex) {
       this.currentTabIndex = 0;
     }
+    this._clickTab();
     console.log("nextTab", this.currentTabIndex);
   }
 
@@ -76,7 +77,16 @@ export class FragmentTabList extends LitElement {
     if (this.currentTabIndex < 0) {
       this.currentTabIndex = this.lastTabIndex;
     }
+    this._clickTab();
     console.log("previousTab", this.currentTabIndex);
+  }
+
+  private _clickTab() {
+    (
+      this.tabs[this.currentTabIndex].shadowRoot?.querySelector(
+        ".tab-item"
+      ) as HTMLElement
+    ).click();
   }
 
   public get lastTabIndex(): number {

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -64,7 +64,7 @@ export class FragmentTabList extends LitElement {
   }
 
   nextTab() {
-    if (this.tabs.length - 1 === this.currentTabIndex) {
+    if (this.currentTabIndex === this.lastTabIndex) {
       this.currentTabIndex = 0;
     } else {
       this.currentTabIndex++;
@@ -74,11 +74,15 @@ export class FragmentTabList extends LitElement {
 
   previousTab() {
     if (this.currentTabIndex <= 0) {
-      this.currentTabIndex = this.tabs.length - 1;
+      this.currentTabIndex = this.lastTabIndex;
     } else {
       this.currentTabIndex--;
     }
     console.log("previousTab", this.currentTabIndex);
+  }
+
+  public get lastTabIndex(): number {
+    return this.tabs.length - 1;
   }
 
   updated() {

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css, TemplateResult } from "lit";
-import { customElement, query, queryAll, state } from "lit/decorators.js";
+import { customElement, query, queryAll } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 import { FragmentsController } from "../controllers/fragments-controller";
 
@@ -12,7 +12,6 @@ export class FragmentTabList extends LitElement {
   @query("sl-tab-group") tabGroup!: HTMLElement;
   @queryAll("fragment-tab") tabs!: Array<HTMLElement>;
   @query(".tab-item[active='true']") activeTab!: HTMLElement;
-  @state() private currentTabIndex = 0;
 
   static styles = css`
     section {
@@ -63,33 +62,33 @@ export class FragmentTabList extends LitElement {
     myAPI.previousTab((_e: Event) => this.previousTab());
   }
 
-  nextTab() {
-    this.currentTabIndex++;
-    if (this.currentTabIndex > this.lastTabIndex) {
-      this.currentTabIndex = 0;
+  private nextTab() {
+    this.fragmentsController.currentTabIndex++;
+    if (this.fragmentsController.currentTabIndex > this.lastTabIndex) {
+      this.fragmentsController.currentTabIndex = 0;
     }
     this._clickTab();
-    console.log("nextTab", this.currentTabIndex);
+    console.log("nextTab", this.fragmentsController.currentTabIndex);
   }
 
-  previousTab() {
-    this.currentTabIndex--;
-    if (this.currentTabIndex < 0) {
-      this.currentTabIndex = this.lastTabIndex;
+  private previousTab() {
+    this.fragmentsController.currentTabIndex--;
+    if (this.fragmentsController.currentTabIndex < 0) {
+      this.fragmentsController.currentTabIndex = this.lastTabIndex;
     }
     this._clickTab();
-    console.log("previousTab", this.currentTabIndex);
+    console.log("previousTab", this.fragmentsController.currentTabIndex);
   }
 
   private _clickTab() {
     (
-      this.tabs[this.currentTabIndex].shadowRoot?.querySelector(
-        ".tab-item"
-      ) as HTMLElement
+      this.tabs[
+        this.fragmentsController.currentTabIndex
+      ].shadowRoot?.querySelector(".tab-item") as HTMLElement
     ).click();
   }
 
-  public get lastTabIndex(): number {
+  private get lastTabIndex(): number {
     return this.tabs.length - 1;
   }
 

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css, TemplateResult } from "lit";
-import { customElement, query, queryAll } from "lit/decorators.js";
+import { customElement, query, queryAll, state } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 import { FragmentsController } from "../controllers/fragments-controller";
 
@@ -10,8 +10,9 @@ export class FragmentTabList extends LitElement {
   private fragmentsController = new FragmentsController(this);
 
   @query("sl-tab-group") tabGroup!: HTMLElement;
-  @queryAll(".tab-item") tabs!: Array<HTMLElement>;
+  @queryAll("fragment-tab") tabs!: Array<HTMLElement>;
   @query(".tab-item[active='true']") activeTab!: HTMLElement;
+  @state() private currentTabIndex = 0;
 
   static styles = css`
     section {
@@ -58,8 +59,26 @@ export class FragmentTabList extends LitElement {
   }
 
   firstUpdated(): void {
-    myAPI.nextTab((_e: Event) => console.log("nextTab"));
-    myAPI.previousTab((_e: Event) => console.log("previousTab"));
+    myAPI.nextTab((_e: Event) => this.nextTab());
+    myAPI.previousTab((_e: Event) => this.previousTab());
+  }
+
+  nextTab() {
+    if (this.tabs.length - 1 === this.currentTabIndex) {
+      this.currentTabIndex = 0;
+    } else {
+      this.currentTabIndex++;
+    }
+    console.log("nextTab", this.currentTabIndex);
+  }
+
+  previousTab() {
+    if (this.currentTabIndex <= 0) {
+      this.currentTabIndex = this.tabs.length - 1;
+    } else {
+      this.currentTabIndex--;
+    }
+    console.log("previousTab", this.currentTabIndex);
   }
 
   updated() {

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -64,19 +64,17 @@ export class FragmentTabList extends LitElement {
   }
 
   nextTab() {
-    if (this.currentTabIndex === this.lastTabIndex) {
+    this.currentTabIndex++;
+    if (this.currentTabIndex > this.lastTabIndex) {
       this.currentTabIndex = 0;
-    } else {
-      this.currentTabIndex++;
     }
     console.log("nextTab", this.currentTabIndex);
   }
 
   previousTab() {
-    if (this.currentTabIndex <= 0) {
+    this.currentTabIndex--;
+    if (this.currentTabIndex < 0) {
       this.currentTabIndex = this.lastTabIndex;
-    } else {
-      this.currentTabIndex--;
     }
     console.log("previousTab", this.currentTabIndex);
   }

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -3,6 +3,8 @@ import { customElement, query, queryAll } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 import { FragmentsController } from "../controllers/fragments-controller";
 
+const { myAPI } = window;
+
 @customElement("fragment-tab-list")
 export class FragmentTabList extends LitElement {
   private fragmentsController = new FragmentsController(this);
@@ -53,6 +55,11 @@ export class FragmentTabList extends LitElement {
 
   render(): TemplateResult {
     return html`${this.tabBarTemplate()}`;
+  }
+
+  firstUpdated(): void {
+    myAPI.nextTab((_e: Event) => console.log("nextTab"));
+    myAPI.previousTab((_e: Event) => console.log("previousTab"));
   }
 
   updated() {

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, css, TemplateResult } from "lit";
-import { customElement, query, queryAll } from "lit/decorators.js";
+import { customElement, queryAll } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 import { FragmentsController } from "../controllers/fragments-controller";
 
@@ -9,9 +9,7 @@ const { myAPI } = window;
 export class FragmentTabList extends LitElement {
   private fragmentsController = new FragmentsController(this);
 
-  @query("sl-tab-group") tabGroup!: HTMLElement;
   @queryAll("fragment-tab") tabs!: Array<HTMLElement>;
-  @query(".tab-item[active='true']") activeTab!: HTMLElement;
 
   static styles = css`
     section {

--- a/src/controllers/fragments-controller.ts
+++ b/src/controllers/fragments-controller.ts
@@ -8,6 +8,7 @@ export class FragmentsController implements ReactiveController {
 
   fragments!: Fragment[];
   activeFragmentId = 0;
+  currentTabIndex = 0;
   snippet?: Snippet;
 
   constructor(host: ReactiveControllerHost) {
@@ -54,7 +55,7 @@ export class FragmentsController implements ReactiveController {
 
     myAPI.fetchFragments(<number>this.snippet._id).then((fragments) => {
       this.fragments = fragments;
-      console.log("Fetch fragments", this.fragments, this.activeFragmentId);
+      this._setCurrentTabIndex();
       this.host.requestUpdate();
     });
   };
@@ -63,6 +64,7 @@ export class FragmentsController implements ReactiveController {
     if (!this.snippet) return;
 
     this.activeFragmentId = e.detail.activeFragmentId;
+    this._setCurrentTabIndex();
     // Update ActiveFragment in Realm DB
     myAPI
       .updateActiveFragment({
@@ -76,4 +78,10 @@ export class FragmentsController implements ReactiveController {
         this.host.requestUpdate();
       });
   };
+
+  private _setCurrentTabIndex() {
+    this.currentTabIndex = Array.from(this.fragments).findIndex(
+      (f) => f._id === this.activeFragmentId
+    );
+  }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,6 +42,8 @@ export interface SandBox {
   ) => Electron.IpcRenderer;
   saveFragment: (listener: (_e: Event) => void) => Electron.IpcRenderer;
   newSnippet: (listener: (_e: Event) => void) => Electron.IpcRenderer;
+  nextTab: (listener: (_e: Event) => void) => Electron.IpcRenderer;
+  previousTab: (listener: (_e: Event) => void) => Electron.IpcRenderer;
 }
 
 // Override properties with type intersection


### PR DESCRIPTION
- Create Menu to switch tab
- Add nextTab and previousTab APIs
- Move the current tab index via shortcuts
- Add lastTabIndex() getter
- Improve +- currentIndex
- Extract logic to _clickTab()
- Use fragmentsController.currentTabIndex for active tab's index
- Remove unused code
