### PR TITLE
refactoring around db

### DIFF
--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -54,21 +54,7 @@ class DB extends Realm {
   createSnippet(title: string): void {
     const snippetUpdate = this.createSnippetUpdate();
 
-    this.write(() => {
-      this.create("Snippet", {
-        _id: this.currentMaxId("Snippet") + 1,
-        title: title,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        snippetUpdate: snippetUpdate,
-      });
-    });
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const latestSnippet: Snippet = this.objectForPrimaryKey(
-      "Snippet",
-      this.currentMaxId("Snippet")
-    )!;
+    const latestSnippet: Snippet = this.createNewSnippet(title, snippetUpdate);
 
     // create an empty fragment
     // TODO: seed data for testing
@@ -81,6 +67,20 @@ class DB extends Realm {
     );
 
     this.createActiveFragment(latestFragment._id, latestSnippet._id);
+  }
+
+  private createNewSnippet(title: string, snippetUpdate: SnippetUpdate) {
+    let snippet!: Snippet;
+    this.write(() => {
+      snippet = this.create("Snippet", {
+        _id: this.currentMaxId("Snippet") + 1,
+        title: title,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        snippetUpdate: snippetUpdate,
+      });
+    });
+    return snippet;
   }
 
   createFragment(

--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -73,13 +73,12 @@ class DB extends Realm {
     // create an empty fragment
     // TODO: seed data for testing
     this.createFragment("", fragments.content1, latestSnippet, 0); // language == 'plaintext'
-    this.createFragment("", fragments.content2, latestSnippet, 0);
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const latestFragment: Fragment = this.objectForPrimaryKey(
-      "Fragment",
-      this.currentMaxId("Fragment")
-    )!;
+    const latestFragment: Fragment = this.createFragment(
+      "",
+      fragments.content2,
+      latestSnippet,
+      0
+    );
 
     this.createActiveFragment(latestFragment._id, latestSnippet._id);
   }
@@ -89,9 +88,10 @@ class DB extends Realm {
     content: string,
     snippet: Snippet,
     languageIdx: number
-  ): void {
+  ): Fragment {
+    let fragment!: Fragment;
     this.write(() => {
-      this.create("Fragment", {
+      fragment = this.create("Fragment", {
         _id: this.currentMaxId("Fragment") + 1,
         title: title,
         content: content,
@@ -101,6 +101,7 @@ class DB extends Realm {
         updatedAt: new Date(),
       });
     });
+    return fragment;
   }
 
   createActiveFragment(fragmentId: number, snippetId: number): void {
@@ -113,7 +114,6 @@ class DB extends Realm {
     });
   }
 
-  // return a new SnippetUpdate object
   createSnippetUpdate(): SnippetUpdate {
     let snippetUpdate!: SnippetUpdate;
     this.write(() => {

--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -53,13 +53,12 @@ class DB extends Realm {
 
   initSnippet(title: string): void {
     const snippetUpdate = this.createSnippetUpdate();
-
-    const latestSnippet: Snippet = this.createSnippet(title, snippetUpdate);
+    const latestSnippet = this.createSnippet(title, snippetUpdate);
 
     // create an empty fragment
     // TODO: seed data for testing
     this.createFragment("", fragments.content1, latestSnippet, 0); // language == 'plaintext'
-    const latestFragment: Fragment = this.createFragment(
+    const latestFragment = this.createFragment(
       "",
       fragments.content2,
       latestSnippet,

--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -54,7 +54,7 @@ class DB extends Realm {
   initSnippet(title: string): void {
     const snippetUpdate = this.createSnippetUpdate();
 
-    const latestSnippet: Snippet = this.createNewSnippet(title, snippetUpdate);
+    const latestSnippet: Snippet = this.createSnippet(title, snippetUpdate);
 
     // create an empty fragment
     // TODO: seed data for testing
@@ -69,7 +69,7 @@ class DB extends Realm {
     this.createActiveFragment(latestFragment._id, latestSnippet._id);
   }
 
-  private createNewSnippet(title: string, snippetUpdate: SnippetUpdate) {
+  private createSnippet(title: string, snippetUpdate: SnippetUpdate) {
     let snippet!: Snippet;
     this.write(() => {
       snippet = this.create("Snippet", {

--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -74,8 +74,6 @@ class DB extends Realm {
       snippet = this.create("Snippet", {
         _id: this.currentMaxId("Snippet") + 1,
         title: title,
-        createdAt: new Date(),
-        updatedAt: new Date(),
         snippetUpdate: snippetUpdate,
       });
     });
@@ -96,8 +94,6 @@ class DB extends Realm {
         content: content,
         snippet: snippet,
         language: this.objectForPrimaryKey("Language", languageIdx) as Language,
-        createdAt: new Date(),
-        updatedAt: new Date(),
       });
     });
     return fragment;
@@ -134,7 +130,6 @@ class DB extends Realm {
     const snippet: Snippet = this.objectForPrimaryKey("Snippet", data._id)!;
     this.write(() => {
       Object.assign(snippet, data.properties);
-      snippet.updatedAt = new Date();
       snippet.snippetUpdate.updatedAt = new Date();
     });
   }
@@ -152,7 +147,6 @@ class DB extends Realm {
     )!;
     this.write(() => {
       Object.assign(fragment, data.properties);
-      fragment.updatedAt = new Date();
       snippetUpdate.updatedAt = new Date();
     });
   }

--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -51,7 +51,7 @@ class DB extends Realm {
     return <number>this.objects(className).max("_id") || 0;
   }
 
-  createSnippet(title: string): void {
+  initSnippet(title: string): void {
     const snippetUpdate = this.createSnippetUpdate();
 
     const latestSnippet: Snippet = this.createNewSnippet(title, snippetUpdate);

--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -104,14 +104,16 @@ class DB extends Realm {
     return fragment;
   }
 
-  createActiveFragment(fragmentId: number, snippetId: number): void {
+  createActiveFragment(fragmentId: number, snippetId: number): ActiveFragment {
+    let activeFragment!: ActiveFragment;
     this.write(() => {
-      this.create("ActiveFragment", {
+      activeFragment = this.create("ActiveFragment", {
         _id: this.currentMaxId("ActiveFragment") + 1,
         fragmentId: fragmentId,
         snippetId: snippetId,
       });
     });
+    return activeFragment;
   }
 
   createSnippetUpdate(): SnippetUpdate {

--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -1,7 +1,6 @@
 import Realm from "realm";
 
 class Snippet {
-  [x: string]: any; // for toJSON()
   public _id = 0;
   public title = "";
   public createdAt = new Date();

--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -3,8 +3,6 @@ import Realm from "realm";
 class Snippet {
   public _id = 0;
   public title = "";
-  public createdAt = new Date();
-  public updatedAt = new Date();
   public snippetUpdate!: SnippetUpdate;
 
   public static schema: Realm.ObjectSchema = {
@@ -12,8 +10,6 @@ class Snippet {
     properties: {
       _id: "int",
       title: "string?",
-      createdAt: "date",
-      updatedAt: "date",
       snippetUpdate: "SnippetUpdate",
     },
     primaryKey: "_id",
@@ -26,8 +22,6 @@ class Fragment {
   public content = "";
   public snippet!: Snippet; // TODO: Change required to optional?
   public language!: Language;
-  public createdAt = new Date();
-  public updatedAt = new Date();
 
   public static schema: Realm.ObjectSchema = {
     name: "Fragment",
@@ -37,8 +31,6 @@ class Fragment {
       content: "string?",
       snippet: "Snippet",
       language: "Language",
-      createdAt: "date",
-      updatedAt: "date",
     },
     primaryKey: "_id",
   };

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -177,7 +177,7 @@ app.once("browser-window-created", () => {
   });
 
   ipcMain.handle("create-snippet", (event) => {
-    db.createSnippet("");
+    db.initSnippet("");
   });
 
   ipcMain.handle("setup-storage", async () => {
@@ -187,7 +187,7 @@ app.once("browser-window-created", () => {
     try {
       if (db.empty) {
         db.initLanguage();
-        db.createSnippet("");
+        db.initSnippet("");
       }
     } catch (err) {
       console.error(err);

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -207,15 +207,11 @@ app.once("browser-window-created", () => {
   });
 
   const loadSnippets = (db: DB): Snippet[] => {
-    const snippets = (
-      db.reverseSortBy(
-        "Snippet",
-        "snippetUpdate.updatedAt"
-      ) as unknown as Results<Snippet>
-    ).map((snippet: Snippet) => {
-      return snippet.toJSON();
-    });
-    return snippets;
+    const snippets = db.reverseSortBy(
+      "Snippet",
+      "snippetUpdate.updatedAt"
+    ) as unknown as Results<Snippet>;
+    return snippets.toJSON();
   };
 
   ipcMain.handle("load-languages", (event) => {

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -176,7 +176,7 @@ app.once("browser-window-created", () => {
     return activeFragment.toJSON();
   });
 
-  ipcMain.handle("create-snippet", (event) => {
+  ipcMain.handle("init-snippet", (event) => {
     db.initSnippet("");
   });
 

--- a/main-process/preload.js
+++ b/main-process/preload.js
@@ -9,7 +9,7 @@ contextBridge.exposeInMainWorld("myAPI", {
   nextTab: (listener) => ipcRenderer.on("next-tab", listener),
   previousTab: (listener) => ipcRenderer.on("previous-tab", listener),
   newSnippet: (listener) => ipcRenderer.on("new-snippet", listener),
-  createSnippet: () => ipcRenderer.invoke("create-snippet"),
+  initSnippet: () => ipcRenderer.invoke("init-snippet"),
   setupStorage: () => ipcRenderer.invoke("setup-storage"),
   updateSnippet: (data) => ipcRenderer.invoke("update-snippet", data),
   updateFragment: (data) => ipcRenderer.invoke("update-fragment", data),

--- a/src/controllers/setup-storage-controller.ts
+++ b/src/controllers/setup-storage-controller.ts
@@ -21,7 +21,7 @@ export class SetupStorageController implements ReactiveController {
       this._updateSnippetsListener as EventListener
     );
     // When Command or Control + N is pressed
-    myAPI.newSnippet((_e: Event) => this._createSnippet());
+    myAPI.newSnippet((_e: Event) => this._initSnippet());
   }
 
   async setupStorage(): Promise<void> {
@@ -55,8 +55,8 @@ export class SetupStorageController implements ReactiveController {
     this._displayToast(e.detail.message);
   };
 
-  private _createSnippet() {
-    myAPI.createSnippet().then(() => {
+  private _initSnippet() {
+    myAPI.initSnippet().then(() => {
       this._loadSnippets();
     });
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,7 +28,7 @@ export interface SandBox {
     status: boolean;
   }>;
   getSnippet: (snippetId: number) => Promise<JSON>;
-  createSnippet: () => Promise<void>;
+  initSnippet: () => Promise<void>;
   getFragment: (fragmentId: number) => Promise<Fragment>;
   getActiveFragment: (snippetId: number) => Promise<ActiveFragment>;
   loadSnippets: () => Promise<Snippet[]>;

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,8 +1,6 @@
 class Snippet {
   _id = 0;
   title = "";
-  createdAt = new Date();
-  updatedAt = new Date();
   snippetUpdate!: SnippetUpdate;
 
   constructor(data: Required<Snippet>) {
@@ -26,8 +24,6 @@ class Fragment {
   public content = "";
   public snippet!: Snippet; // TODO: Change required to optional?
   public language!: Language;
-  public createdAt = new Date();
-  public updatedAt = new Date();
 
   constructor(data: Partial<Fragment>) {
     Object.assign(this, data);


### PR DESCRIPTION
- Use Realm.Collection.toJSON() to return snippets data
- createFragment returns a new fragment
- createActiveFragment returns activeFragment
- Extract createNewSnippet private method that returns a new snippet
- Rename DB.createSnippet to initSnippet
- Rename createSnippet to initSnippet
- Rename createNewSnippet back to createSnippet
- Remove redundant types
- Remove createdAt and updatedAt from Snippet and Fragment
