### PR TITLE
delete fragment via context menu

### DIFF
--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -57,7 +57,7 @@ class DB extends Realm {
 
     // create an empty fragment
     // TODO: seed data for testing
-    this.createFragment("", fragments.content1, latestSnippet, 0); // language == 'plaintext'
+    // this.createFragment("", fragments.content1, latestSnippet, 0); // language == 'plaintext'
     const latestFragment = this.createFragment(
       "",
       fragments.content2,

--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -88,6 +88,29 @@ class DB extends Realm {
     });
   }
 
+  deleteFragment(fragmentId: number, nextActiveFragmentId: number): void {
+    const fragment: Fragment | undefined = this.objectForPrimaryKey(
+      "Fragment",
+      fragmentId
+    );
+
+    if (!fragment) {
+      throw new Error("fragment not found");
+    }
+
+    const snippet: Snippet = fragment.snippet;
+
+    this.write(() => {
+      this.delete(fragment);
+    });
+    this.updateActiveFragment({
+      properties: { snippetId: snippet._id, fragmentId: nextActiveFragmentId },
+    });
+    this.write(() => {
+      snippet.snippetUpdate.updatedAt = new Date();
+    });
+  }
+
   private createSnippet(title: string, snippetUpdate: SnippetUpdate) {
     let snippet!: Snippet;
     this.write(() => {

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -1,5 +1,12 @@
 import path from "path";
-import { app, BrowserWindow, ipcMain } from "electron";
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  Menu,
+  MenuItemConstructorOptions,
+  PopupOptions,
+} from "electron";
 import { setFileSaveAs } from "./setFileSaveAs";
 import { createMenu } from "./createMenu";
 import { JsonStorage, DatapathDoesNotExistError } from "./jsonStorage";
@@ -174,6 +181,23 @@ app.once("browser-window-created", () => {
       .filtered(`snippetId = ${snippetId}`)[0];
     console.log("Main process: get-active-fragment", activeFragment.toJSON());
     return activeFragment.toJSON();
+  });
+
+  ipcMain.handle("show-context-menu", (event) => {
+    const template: MenuItemConstructorOptions[] = [
+      {
+        label: "Menu Item 1",
+        type: "normal",
+        id: "menu-item",
+        click: () => {
+          event.sender.send("context-menu-command", "menu-item-1");
+        },
+      },
+      { type: "separator" },
+      { label: "Menu Item 2", type: "normal" },
+    ];
+    const menu = Menu.buildFromTemplate(template);
+    menu.popup(<PopupOptions>BrowserWindow.fromWebContents(event.sender));
   });
 
   ipcMain.handle("init-snippet", (event) => {

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -198,9 +198,12 @@ app.once("browser-window-created", () => {
     menu.popup(<PopupOptions>BrowserWindow.fromWebContents(event.sender));
   });
 
-  ipcMain.handle("delete-fragment", (event, IdsToDelete) => {
-    console.log(IdsToDelete);
-  });
+  ipcMain.handle(
+    "delete-fragment",
+    (event, ids: { fragmentId: number; nextActiveFragmentId: number }) => {
+      db.deleteFragment(ids.fragmentId, ids.nextActiveFragmentId);
+    }
+  );
 
   ipcMain.handle("init-snippet", (event) => {
     db.initSnippet("");

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -198,6 +198,10 @@ app.once("browser-window-created", () => {
     menu.popup(<PopupOptions>BrowserWindow.fromWebContents(event.sender));
   });
 
+  ipcMain.handle("delete-fragment", (event, IdsToDelete) => {
+    console.log(IdsToDelete);
+  });
+
   ipcMain.handle("init-snippet", (event) => {
     db.initSnippet("");
   });

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -186,15 +186,13 @@ app.once("browser-window-created", () => {
   ipcMain.handle("show-context-menu", (event) => {
     const template: MenuItemConstructorOptions[] = [
       {
-        label: "Menu Item 1",
+        label: "Delete fragment",
         type: "normal",
-        id: "menu-item",
+        id: "delete-fragment",
         click: () => {
-          event.sender.send("context-menu-command", "menu-item-1");
+          event.sender.send("context-menu-command", "delete-fragment");
         },
       },
-      { type: "separator" },
-      { label: "Menu Item 2", type: "normal" },
     ];
     const menu = Menu.buildFromTemplate(template);
     menu.popup(<PopupOptions>BrowserWindow.fromWebContents(event.sender));

--- a/main-process/preload.js
+++ b/main-process/preload.js
@@ -10,6 +10,8 @@ contextBridge.exposeInMainWorld("myAPI", {
   previousTab: (listener) => ipcRenderer.on("previous-tab", listener),
   newSnippet: (listener) => ipcRenderer.on("new-snippet", listener),
   newFragment: (listener) => ipcRenderer.on("new-fragment", listener),
+  contextMenuCommand: (listener) =>
+    ipcRenderer.on("context-menu-command", listener),
   initSnippet: () => ipcRenderer.invoke("init-snippet"),
   initFragment: (snippetId) => ipcRenderer.invoke("init-fragment", snippetId),
   setupStorage: () => ipcRenderer.invoke("setup-storage"),
@@ -25,6 +27,7 @@ contextBridge.exposeInMainWorld("myAPI", {
   getFragment: (fragmentId) => ipcRenderer.invoke("get-fragment", fragmentId),
   getActiveFragment: (snippetId) =>
     ipcRenderer.invoke("get-active-fragment", snippetId),
+  showContextMenu: () => ipcRenderer.invoke("show-context-menu"),
 });
 
 console.log("preload!");

--- a/main-process/preload.js
+++ b/main-process/preload.js
@@ -3,6 +3,7 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("myAPI", {
   fileSaveAs: (fileData) => ipcRenderer.invoke("file-save-as", fileData),
+  // main process -> renderer process
   openByMenu: (listener) => ipcRenderer.on("open-by-menu", listener),
   openSettings: (listener) => ipcRenderer.on("open-settings", listener),
   saveFragment: (listener) => ipcRenderer.on("save-fragment", listener),
@@ -12,11 +13,13 @@ contextBridge.exposeInMainWorld("myAPI", {
   newFragment: (listener) => ipcRenderer.on("new-fragment", listener),
   contextMenuCommand: (listener) =>
     ipcRenderer.on("context-menu-command", listener),
+  // renderer process -> main process
   initSnippet: () => ipcRenderer.invoke("init-snippet"),
   initFragment: (snippetId) => ipcRenderer.invoke("init-fragment", snippetId),
   setupStorage: () => ipcRenderer.invoke("setup-storage"),
   updateSnippet: (data) => ipcRenderer.invoke("update-snippet", data),
   updateFragment: (data) => ipcRenderer.invoke("update-fragment", data),
+  deleteFragment: (data) => ipcRenderer.invoke("delete-fragment", data),
   updateActiveFragment: (data) =>
     ipcRenderer.invoke("update-active-fragment", data),
   loadSnippets: () => ipcRenderer.invoke("load-snippets"),

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -135,7 +135,7 @@ export class FragmentTabList extends LitElement {
 
   private _contextMenuCommand(e: Event, command: string): void {
     if (command === "delete-fragment") {
-      console.info(this.fragmentIdToDelete(this.tabOnContext));
+      myAPI.deleteFragment(this.fragmentIdToDelete(this.tabOnContext));
     }
   }
 

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -5,6 +5,7 @@ import { styleMap } from "lit/directives/style-map.js";
 import { FragmentsController } from "../controllers/fragments-controller";
 import { Fragment } from "models";
 import { IdsOnDeleteFragment } from "index";
+import { dispatch } from "../events/dispatcher";
 
 const { myAPI } = window;
 
@@ -130,7 +131,16 @@ export class FragmentTabList extends LitElement {
 
   private _contextMenuCommand(e: Event, command: string): void {
     if (command === "delete-fragment") {
-      myAPI.deleteFragment(this._idsOnDeleteFragment(this.tabOnContext));
+      myAPI
+        .deleteFragment(this._idsOnDeleteFragment(this.tabOnContext))
+        .then(() => {
+          dispatch({
+            type: "update-snippets",
+            detail: {
+              message: "Fragment deleted",
+            },
+          });
+        });
     }
   }
 

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -3,7 +3,6 @@ import { customElement, queryAll, state } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { FragmentsController } from "../controllers/fragments-controller";
-import { Override } from "index";
 import { Fragment } from "models";
 
 const { myAPI } = window;
@@ -18,10 +17,10 @@ interface FragmentIdToDelete {
   nextActiveFragmentId?: number;
 }
 
-type TabType = Override<
-  HTMLElement,
-  { fragment: Fragment; activeFragmentId: number }
->;
+interface TabType extends HTMLElement {
+  fragment: Fragment;
+  activeFragmentId: number;
+}
 
 @customElement("fragment-tab-list")
 export class FragmentTabList extends LitElement {

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -8,7 +8,7 @@ import { Fragment } from "models";
 
 const { myAPI } = window;
 
-interface IContext {
+interface ITabOnContext {
   fragmentId: number;
   tabIndex: number;
 }
@@ -27,7 +27,7 @@ type TabType = Override<
 export class FragmentTabList extends LitElement {
   private fragmentsController = new FragmentsController(this);
 
-  @state() private onContext!: IContext;
+  @state() private tabOnContext!: ITabOnContext;
   @queryAll("fragment-tab") tabs!: Array<HTMLElement>;
 
   static styles = css`
@@ -92,14 +92,17 @@ export class FragmentTabList extends LitElement {
       (<HTMLElement>e.currentTarget).getAttribute("fragment")!
     );
 
-    this.onContext = {
+    this.tabOnContext = {
       fragmentId: fragment._id,
       tabIndex: Number((<HTMLElement>e.currentTarget).getAttribute("tabIndex")),
     };
     myAPI.showContextMenu();
   }
 
-  fragmentIdToDelete({ fragmentId, tabIndex }: IContext): FragmentIdToDelete {
+  fragmentIdToDelete({
+    fragmentId,
+    tabIndex,
+  }: ITabOnContext): FragmentIdToDelete {
     const tab = Array.from(this.tabs).find(
       (tab) => (<TabType>tab).fragment._id === fragmentId
     ) as TabType;
@@ -132,7 +135,7 @@ export class FragmentTabList extends LitElement {
 
   private _contextMenuCommand(e: Event, command: string): void {
     if (command === "delete-fragment") {
-      console.info(this.fragmentIdToDelete(this.onContext));
+      console.info(this.fragmentIdToDelete(this.tabOnContext));
     }
   }
 

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -73,8 +73,8 @@ export class FragmentTabList extends LitElement {
   }
 
   firstUpdated(): void {
-    myAPI.nextTab((_e: Event) => this.nextTab());
-    myAPI.previousTab((_e: Event) => this.previousTab());
+    myAPI.nextTab((_e: Event) => this._nextTab());
+    myAPI.previousTab((_e: Event) => this._previousTab());
     myAPI.contextMenuCommand((_e: Event, command) =>
       this._contextMenuCommand(_e, command)
     );
@@ -134,7 +134,7 @@ export class FragmentTabList extends LitElement {
     }
   }
 
-  private nextTab() {
+  private _nextTab() {
     this.fragmentsController.currentTabIndex++;
     if (this.fragmentsController.currentTabIndex > this.lastTabIndex) {
       this.fragmentsController.currentTabIndex = 0;
@@ -143,7 +143,7 @@ export class FragmentTabList extends LitElement {
     console.log("nextTab", this.fragmentsController.currentTabIndex);
   }
 
-  private previousTab() {
+  private _previousTab() {
     this.fragmentsController.currentTabIndex--;
     if (this.fragmentsController.currentTabIndex < 0) {
       this.fragmentsController.currentTabIndex = this.lastTabIndex;

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -4,17 +4,13 @@ import { map } from "lit/directives/map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { FragmentsController } from "../controllers/fragments-controller";
 import { Fragment } from "models";
+import { IdsOnDeleteFragment } from "index";
 
 const { myAPI } = window;
 
 interface ITabOnContext {
   fragmentId: number;
   tabIndex: number;
-}
-
-interface FragmentIdToDelete {
-  fragmentId: number;
-  nextActiveFragmentId?: number;
 }
 
 interface TabType extends HTMLElement {
@@ -101,7 +97,7 @@ export class FragmentTabList extends LitElement {
   fragmentIdToDelete({
     fragmentId,
     tabIndex,
-  }: ITabOnContext): FragmentIdToDelete {
+  }: ITabOnContext): IdsOnDeleteFragment {
     const tab = Array.from(this.tabs).find(
       (tab) => (<TabType>tab).fragment._id === fragmentId
     ) as TabType;

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -94,7 +94,7 @@ export class FragmentTabList extends LitElement {
     myAPI.showContextMenu();
   }
 
-  fragmentIdToDelete({
+  private _idsOnDeleteFragment({
     fragmentId,
     tabIndex,
   }: ITabOnContext): IdsOnDeleteFragment {
@@ -130,7 +130,7 @@ export class FragmentTabList extends LitElement {
 
   private _contextMenuCommand(e: Event, command: string): void {
     if (command === "delete-fragment") {
-      myAPI.deleteFragment(this.fragmentIdToDelete(this.tabOnContext));
+      myAPI.deleteFragment(this._idsOnDeleteFragment(this.tabOnContext));
     }
   }
 

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -46,6 +46,7 @@ export class FragmentTabList extends LitElement {
             <fragment-tab
               fragment=${JSON.stringify(fragment)}
               activeFragmentId="${this.fragmentsController.activeFragmentId}"
+              @contextmenu="${this._showContextMenu}"
             ></fragment-tab>
           `;
         })}
@@ -60,6 +61,19 @@ export class FragmentTabList extends LitElement {
   firstUpdated(): void {
     myAPI.nextTab((_e: Event) => this.nextTab());
     myAPI.previousTab((_e: Event) => this.previousTab());
+    myAPI.contextMenuCommand((_e: Event, command) =>
+      this._contextMenuCommand(_e, command)
+    );
+  }
+
+  private _showContextMenu(e: MouseEvent): void {
+    e.preventDefault();
+    // e.stopImmediatePropagation();
+    myAPI.showContextMenu();
+  }
+  private _contextMenuCommand(e: Event, command: string): void {
+    console.log(e);
+    console.log(command);
   }
 
   private nextTab() {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,6 +15,11 @@ export type FileData = {
   text: string;
 };
 
+export interface IdsOnDeleteFragment {
+  fragmentId: number;
+  nextActiveFragmentId?: number;
+}
+
 export interface SandBox {
   fileSaveAs: (fileData: string) => void;
   setupStorage: () => Promise<void>;
@@ -24,7 +29,7 @@ export interface SandBox {
   updateFragment: (data: object) => Promise<{
     status: boolean;
   }>;
-  deleteFragment: (data: object) => Promise<void>;
+  deleteFragment: (data: IdsOnDeleteFragment) => Promise<void>;
   updateActiveFragment: (data: object) => Promise<{
     status: boolean;
   }>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,6 +24,7 @@ export interface SandBox {
   updateFragment: (data: object) => Promise<{
     status: boolean;
   }>;
+  deleteFragment: (data: object) => Promise<void>;
   updateActiveFragment: (data: object) => Promise<{
     status: boolean;
   }>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,6 +32,7 @@ export interface SandBox {
   initFragment: (snippetId: number) => Promise<void>;
   getFragment: (fragmentId: number) => Promise<Fragment>;
   getActiveFragment: (snippetId: number) => Promise<ActiveFragment>;
+  showContextMenu: () => void;
   loadSnippets: () => Promise<Snippet[]>;
   loadLanguages: () => Promise<Language[]>;
   fetchFragments: (snippetId: number) => Promise<Fragment[]>;
@@ -46,6 +47,9 @@ export interface SandBox {
   newFragment: (listener: (_e: Event) => void) => Electron.IpcRenderer;
   nextTab: (listener: (_e: Event) => void) => Electron.IpcRenderer;
   previousTab: (listener: (_e: Event) => void) => Electron.IpcRenderer;
+  contextMenuCommand: (
+    listener: (_e: Event, command: string) => void
+  ) => Electron.IpcRenderer;
 }
 
 // Override properties with type intersection


### PR DESCRIPTION
- Add contextmenu samples
- Rename context menu option name to "Delete fragment"
- Get fragment ID and the next fragment ID on context menu
- Rename interface name
- Add deleteFragment API which sends an object with fragmentId and nextActiveFragmentId
- Use interface instead of Override type to extend HTMLElement properties
- Move interface IdsOnDeleteFragment to index.d.ts
- Rename fragmentIdToDelete() to _idsOnDeleteFragment()
- Add prefix _ to private functions
- Delete fragment via context menu
