### PR TITLE
Downgrade taget and lib options to es2021

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2021",
     "moduleResolution": "node",
     "strict": true,
     "jsx": "preserve",
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "useDefineForClassFields": false,
-    "lib": ["esnext", "dom"],
+    "lib": ["es2021", "dom"],
     "baseUrl": "./"
   }
 }


### PR DESCRIPTION
when building the app, the following error occured.

```
node_modules/@types/verror/index.d.ts:31:5 - error TS2416: Property 'cause' in type 'VError' is not assignable to the same property in base type 'Error'.
  Property 'message' is missing in type '() => Error | undefined' but required in type 'Error'.

31     cause(): Error | undefined;
       ~~~~~

  node_modules/typescript/lib/lib.es5.d.ts:1023:5
    1023     message: string;
             ~~~~~~~
    'message' is declared here.

node_modules/@types/verror/index.d.ts:31:5 - error TS2425: Class 'Error' defines instance member property 'cause', but extended class 'VError' defines it as instance member function.

31     cause(): Error | undefined;
       ~~~~~
```

This may be related to the cause option on new Error, so do not set "esnext" to options
https://devblogs.microsoft.com/typescript/announcing-typescript-4-6/#target-es2022
