### PR TITLE
cleanup code-editor

### DIFF
--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -73,25 +73,12 @@ export class CodeEditor extends LitElement {
     this.viewStateStore = new ViewStateStore();
   }
 
-  private getFile() {
-    if (this.children.length > 0) return this.children[0];
-    return null;
-  }
-
   private getCode(): string {
-    if (this.code) return this.code;
-    const file = this.getFile();
-    if (!file) return "";
-    return file.innerHTML.trim();
+    return this.code;
   }
 
   private getLang() {
     return this.language;
-    // TODO: get rid of this
-    // const file = this.getFile();
-    // if (!file) return;
-    // const type = <string>file.getAttribute("type");
-    // return type.split("/").pop();
   }
 
   private getTheme() {

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -110,10 +110,15 @@ export class CodeEditor extends LitElement {
     this.editor.updateOptions(value);
   }
 
+  get model(): monaco.editor.IModel {
+    const model = this.editor?.getModel();
+    if (model) return model;
+    return monaco.editor.createModel(this.getCode(), this.getLang());
+  }
+
   firstUpdated(): void {
-    const model = monaco.editor.createModel(this.getCode(), this.getLang());
     const editorOptions = {
-      model,
+      model: this.model,
       theme: this.getTheme(),
       automaticLayout: true,
       readOnly: this.readOnly ?? false,

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -125,11 +125,8 @@ export class CodeEditor extends LitElement {
     };
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.editor = monaco.editor.create(this.container.value!, editorOptions);
-    // monaco.editor.setModelLanguage(this.editor.getModel()!, "html");
     console.log(this._langaugesMap());
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    // monaco.editor.setModelLanguage(this.editor.getModel()!, "c");
-    this.editor.getModel()?.onDidChangeContent((e) => {
+    this.model.onDidChangeContent((e) => {
       console.info(e);
       this._changeText();
     });

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -166,13 +166,8 @@ export class CodeEditor extends LitElement {
       }
     }
 
-    const model = this.editor.getModel();
-    if (model) {
-      monaco.editor.setModelLanguage(model, this.getLang());
-      console.log(`model language was changed to ${model.getLanguageId()}`);
-    } else {
-      console.error("editor model is null");
-    }
+    monaco.editor.setModelLanguage(this.model, this.getLang());
+    console.log(`model language was changed to ${this.model.getLanguageId()}`);
     this.setValue(this.code);
 
     console.info("updated", this.viewStateStore.store.getTable("states"));

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -43,7 +43,6 @@ export class CodeEditor extends LitElement {
   private container: Ref<HTMLElement> = createRef();
   editor?: monaco.editor.IStandaloneCodeEditor;
   @property({ type: Boolean, attribute: "readonly" }) readOnly?: boolean;
-  @property() theme?: string;
   @property() language!: string;
   @property() code!: string;
 
@@ -82,7 +81,6 @@ export class CodeEditor extends LitElement {
   }
 
   private getTheme() {
-    if (this.theme) return this.theme;
     if (this.isDark()) return "vs-dark";
     return "vs-light";
   }

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -161,7 +161,6 @@ export class CodeEditor extends LitElement {
       }
     }
 
-    if (!this.editor) return;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     monaco.editor.setModelLanguage(this.editor.getModel()!, this.getLang());
     console.log(

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -161,11 +161,13 @@ export class CodeEditor extends LitElement {
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    monaco.editor.setModelLanguage(this.editor.getModel()!, this.getLang());
-    console.log(
-      `model language was changed to ${this.editor.getModel()?.getLanguageId()}`
-    );
+    const model = this.editor.getModel();
+    if (model) {
+      monaco.editor.setModelLanguage(model, this.getLang());
+      console.log(`model language was changed to ${model.getLanguageId()}`);
+    } else {
+      console.error("editor model is null");
+    }
     this.setValue(this.code);
 
     console.info("updated", this.viewStateStore.store.getTable("states"));

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -205,7 +205,7 @@ export class CodeEditor extends LitElement {
   }
 
   private _saveText() {
-    this._saveCurrentViewState(this.viewStatesController.currentFragmentId!);
+    this._saveCurrentViewState(this.viewStatesController.currentFragmentId);
     this.viewStatesController.previousFragmentId = null;
 
     this.dispatchEvent(

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -41,7 +41,7 @@ export class CodeEditor extends LitElement {
   private viewStatesController = new ViewStatesController(this);
 
   private container: Ref<HTMLElement> = createRef();
-  editor?: monaco.editor.IStandaloneCodeEditor;
+  editor!: monaco.editor.IStandaloneCodeEditor;
   @property({ type: Boolean, attribute: "readonly" }) readOnly?: boolean;
   @property() language!: string;
   @property() code!: string;
@@ -93,11 +93,11 @@ export class CodeEditor extends LitElement {
   }
 
   setValue(value: string): void {
-    this.editor?.setValue(value);
+    this.editor.setValue(value);
   }
 
   getValue(): string {
-    const value = this.editor?.getValue();
+    const value = this.editor.getValue();
     return value || "";
   }
 
@@ -107,7 +107,7 @@ export class CodeEditor extends LitElement {
   }
 
   setOptions(value: monaco.editor.IStandaloneEditorConstructionOptions): void {
-    this.editor?.updateOptions(value);
+    this.editor.updateOptions(value);
   }
 
   firstUpdated(): void {
@@ -180,7 +180,7 @@ export class CodeEditor extends LitElement {
   }
 
   private _saveCurrentViewState(fragmentId: number) {
-    const viewState = this.editor?.saveViewState();
+    const viewState = this.editor.saveViewState();
     this.viewStateStore.setPartialRow(`${fragmentId}`, {
       viewState: JSON.stringify(viewState),
     });
@@ -191,7 +191,7 @@ export class CodeEditor extends LitElement {
       `${this.viewStatesController.currentFragmentId}`,
       "viewState"
     );
-    this.editor?.restoreViewState(JSON.parse(viewState));
+    this.editor.restoreViewState(JSON.parse(viewState));
   }
 
   private _changeText() {

--- a/src/components/home-element.ts
+++ b/src/components/home-element.ts
@@ -29,7 +29,6 @@ export class HomeElement extends LitElement {
       return html`
         ${this.toastTemplate()}
         <editor-element></editor-element>
-        <footer>This is the footer</footer>
       `;
     } else {
       return html`


### PR DESCRIPTION
- Remove getFile()
- Remove theme property
- Change editor to be required
- Change viewStatesController.currentFragmentId to be required
- Remove return if this editor is false
- Remove footer element to prevent showing this accidentally
- Check existence of editor model
- Add model() getter
- Refer this.model when changing a language model
- Refer to this.model for onDidChangeContent()
