### PR TITLE
refactor/fragment tab list

### DIFF
--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -183,7 +183,7 @@ app.once("browser-window-created", () => {
     return activeFragment.toJSON();
   });
 
-  ipcMain.handle("show-context-menu", (event) => {
+  ipcMain.handle("show-context-menu-on-fragment-tab", (event) => {
     const template: MenuItemConstructorOptions[] = [
       {
         label: "Delete fragment",

--- a/main-process/preload.js
+++ b/main-process/preload.js
@@ -28,7 +28,8 @@ contextBridge.exposeInMainWorld("myAPI", {
   getFragment: (fragmentId) => ipcRenderer.invoke("get-fragment", fragmentId),
   getActiveFragment: (snippetId) =>
     ipcRenderer.invoke("get-active-fragment", snippetId),
-  showContextMenu: () => ipcRenderer.invoke("show-context-menu"),
+  showContextMenuOnFragmentTab: () =>
+    ipcRenderer.invoke("show-context-menu-on-fragment-tab"),
 });
 
 console.log("preload!");

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -65,6 +65,18 @@ export class FragmentTabList extends LitElement {
     );
   }
 
+  updated(): void {
+    if (this.fragmentsController.activeFragmentId) {
+      this.dispatchEvent(
+        new CustomEvent("fragment-activated", {
+          detail: {
+            activeFragmentId: this.fragmentsController.activeFragmentId,
+          },
+        })
+      );
+    }
+  }
+
   private _showContextMenu(e: MouseEvent): void {
     e.preventDefault();
     const fragment = JSON.parse(
@@ -148,17 +160,5 @@ export class FragmentTabList extends LitElement {
 
   private get lastTabIndex(): number {
     return this.tabs.length - 1;
-  }
-
-  updated(): void {
-    if (this.fragmentsController.activeFragmentId) {
-      this.dispatchEvent(
-        new CustomEvent("fragment-activated", {
-          detail: {
-            activeFragmentId: this.fragmentsController.activeFragmentId,
-          },
-        })
-      );
-    }
   }
 }

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -130,7 +130,6 @@ export class FragmentTabList extends LitElement {
       this.fragmentsController.currentTabIndex = 0;
     }
     this._clickTab();
-    console.log("nextTab", this.fragmentsController.currentTabIndex);
   }
 
   private _previousTab() {
@@ -139,7 +138,6 @@ export class FragmentTabList extends LitElement {
       this.fragmentsController.currentTabIndex = this.lastTabIndex;
     }
     this._clickTab();
-    console.log("previousTab", this.fragmentsController.currentTabIndex);
   }
 
   private _clickTab() {

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -14,7 +14,7 @@ interface ITabOnContext {
   tabIndex: number;
 }
 
-interface TabType extends HTMLElement {
+interface IFragmentTab extends HTMLElement {
   fragment: Fragment;
   activeFragmentId: number;
 }
@@ -84,16 +84,16 @@ export class FragmentTabList extends LitElement {
     tabIndex,
   }: ITabOnContext): IdsOnDeleteFragment {
     const tab = Array.from(this.tabs).find(
-      (tab) => (<TabType>tab).fragment._id === fragmentId
-    ) as TabType;
+      (tab) => (<IFragmentTab>tab).fragment._id === fragmentId
+    ) as IFragmentTab;
 
     const nextActiveIndex = () => {
       return tabIndex <= 0 ? tabIndex + 1 : tabIndex - 1;
     };
 
     const nextActiveTab = Array.from(this.tabs).find((tab) => {
-      return (<TabType>tab).tabIndex === nextActiveIndex();
-    }) as TabType;
+      return (<IFragmentTab>tab).tabIndex === nextActiveIndex();
+    }) as IFragmentTab;
 
     if (tab.fragment._id === tab.activeFragmentId) {
       return {

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -23,7 +23,7 @@ interface TabType extends HTMLElement {
 export class FragmentTabList extends LitElement {
   private fragmentsController = new FragmentsController(this);
 
-  @state() private tabOnContext!: ITabOnContext;
+  private tabOnContext!: ITabOnContext;
   @queryAll("fragment-tab") tabs!: Array<HTMLElement>;
 
   static styles = css`

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -76,7 +76,7 @@ export class FragmentTabList extends LitElement {
       fragmentId: fragment._id,
       tabIndex: Number((<HTMLElement>e.currentTarget).getAttribute("tabIndex")),
     };
-    myAPI.showContextMenu();
+    myAPI.showContextMenuOnFragmentTab();
   }
 
   private _idsOnDeleteFragment({

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -95,9 +95,7 @@ export class FragmentTabList extends LitElement {
       return (<TabType>tab).tabIndex === nextActiveIndex();
     }) as TabType;
 
-    const isActiveTab = tab.fragment._id === tab.activeFragmentId;
-
-    if (isActiveTab) {
+    if (tab.fragment._id === tab.activeFragmentId) {
       return {
         fragmentId: tab.fragment._id,
         nextActiveFragmentId: nextActiveTab.fragment._id,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -47,7 +47,7 @@ export interface SandBox {
   getSnippet: (snippetId: number) => Promise<JSON>;
   getFragment: (fragmentId: number) => Promise<Fragment>;
   getActiveFragment: (snippetId: number) => Promise<ActiveFragment>;
-  showContextMenu: () => void;
+  showContextMenuOnFragmentTab: () => void;
 }
 
 // Override properties with type intersection


### PR DESCRIPTION
- Change tabOnContext from state to property
- Remove console.log
- Inline isActiveTab
- Rename TabType to IFragmentTab
- Rename showContextMenu() to showContextMenuOnFragmentTab()
- Move update() to below firstUpdated()
