### PR TITLE
refactor/fragment tab

### DIFF
--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -1,6 +1,6 @@
 import { dispatch } from "../events/dispatcher";
 import { LitElement, html, css, TemplateResult } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, query, state } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 import { createFragmentStore, Store } from "../stores";
 import { Language } from "models.d";
@@ -37,7 +37,6 @@ export class EditorElement extends LitElement {
     });
   }
 
-  @property() _textareaValue = "";
   @query("#lang-select") select!: HTMLSelectElement;
   @state()
   private _activeFragmentId?: number;
@@ -78,7 +77,7 @@ export class EditorElement extends LitElement {
   render(): TemplateResult {
     return html`
       <section>
-        <test-header textareaValue="${this._textareaValue}"></test-header>
+        <test-header></test-header>
         <fragment-tab-list
           @fragment-activated=${this._onFragmentActivated}
         ></fragment-tab-list>

--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -123,7 +123,6 @@ export class EditorElement extends LitElement {
     this.fragmentStore.setPartialRow("states", `${this._activeFragmentId}`, {
       langIdx: Number(_idx),
     });
-    this._setContent();
   }
 
   private _onFragmentActivated(e: CustomEvent): void {

--- a/src/components/fragment-tab.ts
+++ b/src/components/fragment-tab.ts
@@ -1,6 +1,6 @@
 import { dispatch } from "../events/dispatcher";
 import { LitElement, html, css, TemplateResult } from "lit";
-import { customElement, property, query, queryAll } from "lit/decorators.js";
+import { customElement, property, queryAll } from "lit/decorators.js";
 import { Fragment } from "models.d";
 import { Store } from "stores";
 
@@ -9,7 +9,6 @@ export class FragmentTab extends LitElement {
   @property({ type: Object }) fragment!: Fragment;
   @property({ type: Number }) activeFragmentId!: number;
   @queryAll(".tab-item") tabs!: Array<HTMLElement>;
-  @query(".tab-item[active='true']") activeTab!: HTMLElement;
 
   static styles = css`
     :host {

--- a/src/components/fragment-tab.ts
+++ b/src/components/fragment-tab.ts
@@ -46,7 +46,7 @@ export class FragmentTab extends LitElement {
       : html``;
   }
 
-  tabBarTemplate(): TemplateResult {
+  render(): TemplateResult {
     return html`
       <div
         id="fragment-${this.fragment._id}"
@@ -61,10 +61,6 @@ export class FragmentTab extends LitElement {
         <div class="tab-icon">${this.iconTemplate()}</div>
       </div>
     `;
-  }
-
-  render(): TemplateResult {
-    return html`${this.tabBarTemplate()}`;
   }
 
   firstUpdated(): void {

--- a/src/components/fragment-tab.ts
+++ b/src/components/fragment-tab.ts
@@ -41,7 +41,6 @@ export class FragmentTab extends LitElement {
   private _fragmentStore: typeof Store;
 
   iconTemplate(): TemplateResult {
-    // TODO: Do not display icon temporarily
     return this._isEditing
       ? html` <sl-icon name="record-fill"></sl-icon> `
       : html``;


### PR DESCRIPTION
- Remove obsolete activeTab
- Remove comment
- Move template from tabBarTemplate() into render()
- Remove obsolete _textareaValue property
- Do not set a content to fragmentStore() on _selectionChange()
