### PR TITLE
Add ActiveSnippetHistory

### DIFF
--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -216,6 +216,26 @@ class DB extends Realm {
       }
     });
   }
+
+  resetActiveSnippetHistory(): void {
+    this.write(() => {
+      // delete all activeSnippetHistory except the latest one
+      this.delete(
+        this.objects("ActiveSnippetHistory").filtered(
+          `_id != ${this.currentMaxId("ActiveSnippetHistory")}`
+        )
+      );
+      // update _id of the latest one to 1
+      const latestOne: ActiveSnippetHistory | undefined =
+        this.objectForPrimaryKey(
+          "ActiveSnippetHistory",
+          this.currentMaxId("ActiveSnippetHistory")
+        );
+      if (latestOne) {
+        latestOne._id = 1;
+      }
+    });
+  }
 }
 
 export default DB;

--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -5,6 +5,7 @@ import {
   ActiveFragment,
   Language,
   SnippetUpdate,
+  ActiveSnippetHistory,
 } from "./realm";
 import languages from "./seeds/languages";
 import * as fragments from "./seeds/fragments";
@@ -21,6 +22,7 @@ class DB extends Realm {
       ActiveFragment.schema,
       Language.schema,
       SnippetUpdate.schema,
+      ActiveSnippetHistory.schema,
     ];
     super({ path, schema });
   }
@@ -165,6 +167,15 @@ class DB extends Realm {
       });
     });
     return snippetUpdate;
+  }
+
+  createActiveSnippetHistory(snippetId: number): void {
+    this.write(() => {
+      this.create("ActiveSnippetHistory", {
+        _id: this.currentMaxId("ActiveSnippetHistory") + 1,
+        snippetId,
+      });
+    });
   }
 
   updateSnippet(props: { _id: number; properties: typeof Snippet }): void {

--- a/main-process/db/realm.ts
+++ b/main-process/db/realm.ts
@@ -94,4 +94,26 @@ class SnippetUpdate {
   };
 }
 
-export { Realm, Snippet, Fragment, ActiveFragment, Language, SnippetUpdate };
+class ActiveSnippetHistory {
+  public _id = 0;
+  public snippetId = 0;
+
+  public static schema: Realm.ObjectSchema = {
+    name: "ActiveSnippetHistory",
+    properties: {
+      _id: "int",
+      snippetId: "int",
+    },
+    primaryKey: "_id",
+  };
+}
+
+export {
+  Realm,
+  Snippet,
+  Fragment,
+  ActiveFragment,
+  Language,
+  SnippetUpdate,
+  ActiveSnippetHistory,
+};

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -204,6 +204,7 @@ app.once("browser-window-created", () => {
 
   ipcMain.handle("init-snippet", (event) => {
     db.initSnippet("");
+    return db.reverseSortBy("Snippet", "_id")[0].toJSON();
   });
 
   ipcMain.handle("init-fragment", (event, snippetId) => {

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -260,6 +260,10 @@ app.once("browser-window-created", () => {
   ipcMain.handle("new-active-snippet-history", (event, snippetId) => {
     db.createActiveSnippetHistory(snippetId);
   });
+
+  ipcMain.handle("get-latest-active-snippet-history", (event) => {
+    return db.reverseSortBy("ActiveSnippetHistory", "_id")[0].toJSON();
+  });
 });
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -263,7 +263,7 @@ app.once("browser-window-created", () => {
   });
 
   ipcMain.handle("get-latest-active-snippet-history", (event) => {
-    return db.reverseSortBy("ActiveSnippetHistory", "_id")[0].toJSON();
+    return db.reverseSortBy("ActiveSnippetHistory", "_id")[0]?.toJSON();
   });
 });
 

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -267,11 +267,15 @@ app.once("browser-window-created", () => {
   });
 });
 
+app.on("will-quit", () => {
+  db.resetActiveSnippetHistory();
+  db.close();
+});
+
 // Quit when all windows are closed, except on macOS. There, it's common
 // for applications and their menu bar to stay active until the user quits
 // explicitly with Cmd + Q.
 app.on("window-all-closed", () => {
-  db.close();
   if (process.platform !== "darwin") {
     app.quit();
   }

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -256,6 +256,10 @@ app.once("browser-window-created", () => {
       .filtered(`snippet._id == ${snippetId}`) as unknown as Results<Fragment>;
     return fragments.toJSON();
   });
+
+  ipcMain.handle("new-active-snippet-history", (event, snippetId) => {
+    db.createActiveSnippetHistory(snippetId);
+  });
 });
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/main-process/preload.js
+++ b/main-process/preload.js
@@ -16,6 +16,8 @@ contextBridge.exposeInMainWorld("myAPI", {
   initSnippet: () => ipcRenderer.invoke("init-snippet"),
   initFragment: (snippetId) => ipcRenderer.invoke("init-fragment", snippetId),
   setupStorage: () => ipcRenderer.invoke("setup-storage"),
+  newActiveSnippetHistory: (snippetId) =>
+    ipcRenderer.invoke("new-active-snippet-history", snippetId),
   updateSnippet: (props) => ipcRenderer.invoke("update-snippet", props),
   updateFragment: (props) => ipcRenderer.invoke("update-fragment", props),
   deleteFragment: (ids) => ipcRenderer.invoke("delete-fragment", ids),

--- a/main-process/preload.js
+++ b/main-process/preload.js
@@ -30,6 +30,8 @@ contextBridge.exposeInMainWorld("myAPI", {
   getFragment: (fragmentId) => ipcRenderer.invoke("get-fragment", fragmentId),
   getActiveFragment: (snippetId) =>
     ipcRenderer.invoke("get-active-fragment", snippetId),
+  getLatestActiveSnippetHistory: () =>
+    ipcRenderer.invoke("get-latest-active-snippet-history"),
   showContextMenuOnFragmentTab: () =>
     ipcRenderer.invoke("show-context-menu-on-fragment-tab"),
 });

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -94,11 +94,23 @@ export class SnippetList extends LitElement {
 
   updated(): void {
     if (!this.snippetItems[0]) return;
-    // Select the first item on the top of the list
-    const topItem = Array.from(this.snippetItems).find(
-      (item) => item.getAttribute("itemindex") === "0"
+    console.info(
+      "snippet-list:updated",
+      this.setupStorage.activeSnippetHistory
     );
-    this._updateSelectedItem(topItem!);
+
+    // topItem is the first item in the list or the item that was selected before
+    let topItem = this.snippetItems[0];
+    if (this.setupStorage.activeSnippetHistory) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      topItem = Array.from(this.snippetItems).find(
+        (item) =>
+          Number(item.getAttribute("snippet-id")) ===
+          this.setupStorage.activeSnippetHistory.snippetId
+      )!;
+    }
+
+    this._updateSelectedItem(topItem);
   }
 
   private _updateSelectedItem(item: HTMLLIElement): void {
@@ -113,10 +125,7 @@ export class SnippetList extends LitElement {
       detail: { selectedItems: [item] },
     });
     this.snippetList.dispatchEvent(event);
-    this.scroll({ top: 0, behavior: "smooth" });
-    // e.g. scroll to the top of the second item
-    // this.snippetItems[1] &&
-    //   this.scroll({ top: this.snippetItems[1].offsetTop, behavior: "smooth" });
+    this.scroll({ top: item.offsetTop, behavior: "smooth" });
   }
 
   private formatDatetime(datetime: Date): string {

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -49,7 +49,7 @@ export class SnippetList extends LitElement {
         ${repeat(
           this.setupStorage.snippets,
           (snippet: Snippet) => snippet._id,
-          (snippet: Snippet) =>
+          (snippet: Snippet, index) =>
             html`<ui5-li
               description="${this.formatDatetime(
                 snippet.snippetUpdate.updatedAt
@@ -60,6 +60,7 @@ export class SnippetList extends LitElement {
               )} 📄"
               additional-text-state="Success"
               snippet=${JSON.stringify(snippet)}
+              itemindex="${index}"
               >${snippet.title}</ui5-li
             >`
         )}
@@ -88,7 +89,10 @@ export class SnippetList extends LitElement {
   updated(): void {
     if (!this.snippetItems[0]) return;
     // Select the first item on the top of the list
-    this._updateSelectedItem(this.snippetItems[0]);
+    const topItem = Array.from(this.snippetItems).find(
+      (item) => item.getAttribute("itemindex") === "0"
+    );
+    this._updateSelectedItem(topItem!);
   }
 
   private _updateSelectedItem(item: HTMLLIElement): void {

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -17,6 +17,7 @@ export class SnippetList extends LitElement {
 
   @query("#snippetList") snippetList!: HTMLElement;
   @queryAll("ui5-li") snippetItems!: HTMLLIElement[];
+  snippet!: Snippet;
 
   constructor() {
     super();
@@ -60,6 +61,7 @@ export class SnippetList extends LitElement {
               )} 📄"
               additional-text-state="Success"
               snippet=${JSON.stringify(snippet)}
+              snippet-id=${snippet._id}
               itemindex="${index}"
               >${snippet.title}</ui5-li
             >`
@@ -72,6 +74,10 @@ export class SnippetList extends LitElement {
     this.snippetList.addEventListener("selection-change", ((
       e: CustomEvent
     ): void => {
+      this.snippet = JSON.parse(
+        e.detail.selectedItems[0].getAttribute("snippet")
+      );
+
       const previouslySelectedSnippet = e.detail.previouslySelectedItems
         ? e.detail.previouslySelectedItems[0].getAttribute("snippet")
         : null;

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -50,7 +50,7 @@ export class SnippetList extends LitElement {
         ${repeat(
           this.setupStorage.snippets,
           (snippet: Snippet) => snippet._id,
-          (snippet: Snippet, index) =>
+          (snippet: Snippet) =>
             html`<ui5-li
               description="${this.formatDatetime(
                 snippet.snippetUpdate.updatedAt
@@ -62,7 +62,6 @@ export class SnippetList extends LitElement {
               additional-text-state="Success"
               snippet=${JSON.stringify(snippet)}
               snippet-id=${snippet._id}
-              itemindex="${index}"
               >${snippet.title}</ui5-li
             >`
         )}

--- a/src/controllers/fragments-controller.ts
+++ b/src/controllers/fragments-controller.ts
@@ -58,6 +58,8 @@ export class FragmentsController implements ReactiveController {
     this.snippet = JSON.parse(e.detail.selectedSnippet);
     if (!this.snippet) return;
 
+    myAPI.newActiveSnippetHistory(<number>this.snippet._id);
+
     // Get the snippet by id from Realm DB
     myAPI.getSnippet(<number>this.snippet._id).then((snippet) => {
       this.snippet = snippet as unknown as Snippet;

--- a/src/controllers/setup-storage-controller.ts
+++ b/src/controllers/setup-storage-controller.ts
@@ -62,7 +62,8 @@ export class SetupStorageController implements ReactiveController {
   };
 
   private _initSnippet() {
-    myAPI.initSnippet().then(() => {
+    myAPI.initSnippet().then((snippet) => {
+      myAPI.newActiveSnippetHistory(snippet._id);
       this._loadSnippets();
     });
   }

--- a/src/controllers/setup-storage-controller.ts
+++ b/src/controllers/setup-storage-controller.ts
@@ -1,12 +1,13 @@
 import { dispatch } from "../events/dispatcher";
 import { ReactiveController, ReactiveControllerHost } from "lit";
-import { Snippet } from "../models";
+import { Snippet, ActiveSnippetHistory } from "../models";
 const { myAPI } = window;
 
 export class SetupStorageController implements ReactiveController {
   private host: ReactiveControllerHost;
 
   snippets: Snippet[] = [];
+  activeSnippetHistory!: ActiveSnippetHistory;
 
   constructor(host: ReactiveControllerHost) {
     this.host = host;
@@ -35,12 +36,6 @@ export class SetupStorageController implements ReactiveController {
         console.error(err);
         this._displayToast("Setup failed");
       });
-    await this._getLatestActiveSnippetId();
-  }
-
-  private async _getLatestActiveSnippetId(): Promise<void> {
-    const history = await myAPI.getLatestActiveSnippetHistory();
-    console.info(history);
   }
 
   private _loadSnippets() {
@@ -54,7 +49,10 @@ export class SetupStorageController implements ReactiveController {
         this._displayToast("Snippets load failed");
       })
       .finally(() => {
-        this.host.requestUpdate();
+        myAPI.getLatestActiveSnippetHistory().then((activeSnippetHistory) => {
+          this.activeSnippetHistory = activeSnippetHistory;
+          this.host.requestUpdate();
+        });
       });
   }
 

--- a/src/controllers/setup-storage-controller.ts
+++ b/src/controllers/setup-storage-controller.ts
@@ -35,6 +35,12 @@ export class SetupStorageController implements ReactiveController {
         console.error(err);
         this._displayToast("Setup failed");
       });
+    await this._getLatestActiveSnippetId();
+  }
+
+  private async _getLatestActiveSnippetId(): Promise<void> {
+    const history = await myAPI.getLatestActiveSnippetHistory();
+    console.info(history);
   }
 
   private _loadSnippets() {

--- a/src/controllers/setup-storage-controller.ts
+++ b/src/controllers/setup-storage-controller.ts
@@ -42,11 +42,13 @@ export class SetupStorageController implements ReactiveController {
       .loadSnippets()
       .then((snippets) => {
         this.snippets = snippets;
-        this.host.requestUpdate();
       })
       .catch((err) => {
         console.error(err);
         this._displayToast("Snippets load failed");
+      })
+      .finally(() => {
+        this.host.requestUpdate();
       });
   }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -34,7 +34,7 @@ export interface SandBox {
     listener: (_e: Event, command: string) => void
   ) => Electron.IpcRenderer;
   // renderer process -> main process
-  initSnippet: () => Promise<void>;
+  initSnippet: () => Promise<Snippet>;
   initFragment: (snippetId: number) => Promise<void>;
   setupStorage: () => Promise<void>;
   newActiveSnippetHistory: (snippetId: number) => Promise<void>;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,12 @@
 /* eslint-disable no-unused-vars */
 import { IpcRenderer } from "electron";
-import { Fragment, ActiveFragment, Snippet, Language } from "models.d";
+import {
+  Fragment,
+  ActiveFragment,
+  Snippet,
+  Language,
+  ActiveSnippetHistory,
+} from "models.d";
 import { ISnippetProps, IFragmentProps } from "props.d";
 
 declare global {
@@ -48,6 +54,7 @@ export interface SandBox {
   getSnippet: (snippetId: number) => Promise<JSON>;
   getFragment: (fragmentId: number) => Promise<Fragment>;
   getActiveFragment: (snippetId: number) => Promise<ActiveFragment>;
+  getLatestActiveSnippetHistory: () => Promise<ActiveSnippetHistory>;
   showContextMenuOnFragmentTab: () => void;
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,6 +31,7 @@ export interface SandBox {
   initSnippet: () => Promise<void>;
   initFragment: (snippetId: number) => Promise<void>;
   setupStorage: () => Promise<void>;
+  newActiveSnippetHistory: (snippetId: number) => Promise<void>;
   updateSnippet: (props: ISnippetProps) => Promise<void>;
   updateFragment: (props: IFragmentProps) => Promise<{
     status: boolean;

--- a/src/models.d.ts
+++ b/src/models.d.ts
@@ -29,4 +29,16 @@ interface SnippetUpdate {
   updatedAt: Date;
 }
 
-export { Snippet, Language, Fragment, ActiveFragment, SnippetUpdate };
+interface ActiveSnippetHistory {
+  _id: number;
+  snippetId: number;
+}
+
+export {
+  Snippet,
+  Language,
+  Fragment,
+  ActiveFragment,
+  SnippetUpdate,
+  ActiveSnippetHistory,
+};


### PR DESCRIPTION
- Add ActiveSnippetHistory model
- Get an item on the top via itemindex attribute
- Add snippet property to store snippet data from JSON.parse()
- Call requestUpdate() in finally block
- Implement getLatestActiveSnippetHistory()
- Scroll the latest active snippet item to the top
- Create ActiveSnippetHistory on creating a new snippet to scroll it to the top
- Delete all ActiveSnippetHistory records except the latest one before the app will quit
- Remove index no longer used
- Return null if no ActiveSnippetHistory records
