### PR TITLE
Set the content on _selectionChange()

### DIFF
--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -123,6 +123,7 @@ export class EditorElement extends LitElement {
     this.fragmentStore.setPartialRow("states", `${this._activeFragmentId}`, {
       langIdx: Number(_idx),
     });
+    this._setContent();
   }
 
   private _onFragmentActivated(e: CustomEvent): void {


### PR DESCRIPTION
Avoid the situation at selecting a language while text is being edited would cause the text state to revert to one of the previous states
