### PR TITLE
rotate icon on edit

### DIFF
--- a/src/components.ts
+++ b/src/components.ts
@@ -8,3 +8,4 @@ import "./components/search-item";
 import "./components/fragment-tab";
 import "./components/fragment-tab-list";
 import "./components/fragment-title";
+import "./components/editing-state-icon";

--- a/src/components/editing-state-icon.ts
+++ b/src/components/editing-state-icon.ts
@@ -1,0 +1,98 @@
+import { LitElement, html, css, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { Store } from "stores";
+
+@customElement("editing-state-icon")
+export class EditingStateIcon extends LitElement {
+  @state() private _isEditing!: boolean;
+  private _fragmentStore: typeof Store;
+
+  static styles = css`
+    :host {
+      display: flex;
+      justify-content: flex-end;
+    }
+    .editing-state-icon {
+      display: inline-flex;
+      width: 19px;
+      padding: 0 5px;
+      justify-content: center;
+      align-items: center;
+    }
+    .rotate-icon {
+      animation: rotation 2s linear infinite;
+    }
+    @keyframes rotation {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(359deg);
+      }
+    }
+  `;
+
+  iconTemplate(): TemplateResult {
+    return this._isEditing
+      ? html` <sl-icon name="arrow-repeat" class="rotate-icon"></sl-icon> `
+      : html``;
+  }
+
+  render(): TemplateResult {
+    return html` <div class="editing-state-icon">${this.iconTemplate()}</div> `;
+  }
+
+  firstUpdated(): void {
+    window.addEventListener(
+      "content-editing-state-changed",
+      this._stateChangedListener as EventListener
+    );
+    window.addEventListener(
+      "snippet-selected",
+      this._snippetSelectedListener as EventListener
+    );
+    window.addEventListener(
+      "active-fragment",
+      this._activeFragmentListener as EventListener
+    );
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+
+    window.removeEventListener(
+      "content-editing-state-changed",
+      this._stateChangedListener as EventListener
+    );
+    window.removeEventListener(
+      "snippet-selected",
+      this._snippetSelectedListener as EventListener
+    );
+    window.removeEventListener(
+      "active-fragment",
+      this._activeFragmentListener as EventListener
+    );
+  }
+
+  private _snippetSelectedListener = (e: CustomEvent) => {
+    // e.detail.to is active fragment ID
+    this._setIsEditing(e.detail.to);
+  };
+
+  private _activeFragmentListener = (e: CustomEvent) => {
+    this._setIsEditing(e.detail.activeFragmentId);
+  };
+
+  private _stateChangedListener = (e: CustomEvent): void => {
+    this._fragmentStore = e.detail.fragmentStore;
+    this._setIsEditing(e.detail._id);
+  };
+
+  private _setIsEditing(fragmentId: number) {
+    this._isEditing = !!this._fragmentStore?.getCell(
+      "states",
+      `${fragmentId}`,
+      "isEditing"
+    );
+  }
+}

--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -100,6 +100,7 @@ export class EditorElement extends LitElement {
             </option>`;
           })}
         </select>
+        <editing-state-icon></editing-state-icon>
       </footer>
     `;
   }

--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -42,7 +42,7 @@ export class EditorElement extends LitElement {
   private _activeFragmentId?: number;
   @state() private _content = "";
   @state() private _language = "plaintext";
-  @state() private _languages!: Language[];
+  private _languages!: Language[];
 
   static styles = [
     css`

--- a/src/components/fragment-tab.ts
+++ b/src/components/fragment-tab.ts
@@ -37,23 +37,12 @@ export class FragmentTab extends LitElement {
       justify-content: center;
       align-items: center;
     }
-    .rotate-icon {
-      animation: rotation 2s linear infinite;
-    }
-    @keyframes rotation {
-      from {
-        transform: rotate(0deg);
-      }
-      to {
-        transform: rotate(359deg);
-      }
-    }
   `;
   private _fragmentStore: typeof Store;
 
   iconTemplate(): TemplateResult {
     return this._isEditing
-      ? html` <sl-icon name="arrow-repeat" class="rotate-icon"></sl-icon> `
+      ? html` <sl-icon name="record-fill"></sl-icon> `
       : html``;
   }
 

--- a/src/components/fragment-tab.ts
+++ b/src/components/fragment-tab.ts
@@ -37,12 +37,23 @@ export class FragmentTab extends LitElement {
       justify-content: center;
       align-items: center;
     }
+    .rotate-icon {
+      animation: rotation 2s linear infinite;
+    }
+    @keyframes rotation {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(359deg);
+      }
+    }
   `;
   private _fragmentStore: typeof Store;
 
   iconTemplate(): TemplateResult {
     return this._isEditing
-      ? html` <sl-icon name="record-fill"></sl-icon> `
+      ? html` <sl-icon name="arrow-repeat" class="rotate-icon"></sl-icon> `
       : html``;
   }
 

--- a/src/components/fragment-tab.ts
+++ b/src/components/fragment-tab.ts
@@ -90,10 +90,9 @@ export class FragmentTab extends LitElement {
   }
 
   private _stateChangedListener = (e: CustomEvent): void => {
-    this._fragmentStore = e.detail.fragmentStore;
     if (this.fragment._id !== e.detail._id) return;
 
-    this._fragmentStore.getCell("states", `${e.detail._id}`, "isEditing");
+    this._fragmentStore = e.detail.fragmentStore;
     this.requestUpdate();
   };
 


### PR DESCRIPTION
- Do not state for _languages
- Rotate icon on fragment tab on edit
- Remove obsolete code from _stateChangedListener()
- Add EditingStateIcon element
- Revert "Rotate icon on fragment tab on edit"
