### PR TITLE
Improve saveContentAsync()

### DIFF
--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -132,8 +132,8 @@ export class CodeEditor extends LitElement {
     this.editor.onDidFocusEditorText(() => {
       console.log("focus");
     });
-    this.editor.onDidBlurEditorText(() => {
-      console.log("blur");
+    this.editor.onDidBlurEditorText((e) => {
+      this.dispatchEvent(new CustomEvent("blur-editor"));
     });
     // When Command or Control + S is pressed
     myAPI.saveFragment((_e: Event) => this._saveText());

--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -87,6 +87,7 @@ export class EditorElement extends LitElement {
           language="${this._language}"
           @change-text=${this._changeText}
           @save-text=${this._saveText}
+          @blur-editor=${this._onBlurEditor}
         ></code-editor>
       </section>
       <footer>
@@ -191,7 +192,7 @@ export class EditorElement extends LitElement {
         // auto save
         if (!e.detail.isComposing) {
           saveContentAsync(
-            this._activeFragmentId,
+            this._activeFragmentId as number,
             e.detail.text,
             this.fragmentStore
           );
@@ -204,6 +205,15 @@ export class EditorElement extends LitElement {
     if (this._activeFragmentId === undefined) return;
 
     saveContent(this._activeFragmentId, e.detail.text, this.fragmentStore);
+  }
+
+  private _onBlurEditor(e: CustomEvent): void {
+    dispatch({
+      type: "update-snippets",
+      detail: {
+        message: "Snippets updated",
+      },
+    });
   }
 
   private _setContent(): void {


### PR DESCRIPTION
Dispatch update-snippets event on blur the editor
Do not dispatch update-snippets event on manual-save

Use early return and await _sleep() later

Ensure to pass this._activeFragmentId as number, not undefined
because using early return in _changeText() first, so this._activeFragmentId is a number when it's passed to saveContentAsync()

the queue never contains undefined, so type the return value as number from queue.shift()
it does not need to check whether currentFragmentId is undefined or not, currentFragmentId is a number via queue.shift()
