### PR TITLE
Enable to update fragment title

### DIFF
--- a/index.css
+++ b/index.css
@@ -37,6 +37,7 @@ snippet-list::-webkit-scrollbar {
   --gray: #717172;
   --dark-gray: #323233;
   --text-color: ghostwhite;
+  --placeholder-color: rgb(190, 190, 190);
   --header-height: 51px;
   --header-height-offset: 26px;
 }

--- a/src/components/fragment-tab.ts
+++ b/src/components/fragment-tab.ts
@@ -56,7 +56,9 @@ export class FragmentTab extends LitElement {
         @click="${this._onClickListener}"
       >
         <div class="tab-item-inner">
-          ${this.fragment.title || `fragment ${this.fragment._id}`}
+          <fragment-title
+            fragment=${JSON.stringify(this.fragment)}
+          ></fragment-title>
         </div>
         <div class="tab-icon">${this.iconTemplate()}</div>
       </div>

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -15,6 +15,7 @@ export class FragmentTitle extends LitElement {
   static styles = [
     css`
       :host {
+        width: 100%;
       }
 
       input {
@@ -22,6 +23,7 @@ export class FragmentTitle extends LitElement {
         color: white;
         border: none;
         text-align: center;
+        width: 100%;
       }
       input[readonly] {
         outline: none;

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, TemplateResult, css } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, property, query } from "lit/decorators.js";
 import { live } from "lit/directives/live.js";
 import { Fragment } from "models.d";
 import { dispatch } from "../events/dispatcher";
@@ -9,10 +9,7 @@ const { myAPI } = window;
 @customElement("fragment-title")
 export class FragmentTitle extends LitElement {
   @query("input") private inputElement!: HTMLInputElement;
-  @property({ type: String })
-  title = "";
   @property({ type: Object }) fragment!: Fragment;
-  @state() editable = false;
 
   static styles = [
     css`

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -9,8 +9,6 @@ export class FragmentTitle extends LitElement {
   @query("input") private inputElement!: HTMLInputElement;
   @property({ type: String })
   title = "";
-  @property({ type: Number })
-  fragmentId!: number;
   @property({ type: Object }) fragment!: Fragment;
   @state() editable = false;
 
@@ -31,6 +29,9 @@ export class FragmentTitle extends LitElement {
       input:not([readonly]):focus-visible {
         outline: var(--sl-color-primary-600) solid 1px;
       }
+      input::placeholder {
+        color: var(--placeholder-color);
+      }
     `,
   ];
 
@@ -38,7 +39,7 @@ export class FragmentTitle extends LitElement {
     return html`
       <input
         type="text"
-        .value=${live(this.fragment.title) || "untitled"}
+        .value=${live(this.fragment.title)}
         placeholder="untitled"
         readonly
         @dblclick="${this._enableEdit}"

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -77,6 +77,7 @@ export class FragmentTitle extends LitElement {
   private _disableEditOnBlur(e: FocusEvent) {
     const target = <HTMLInputElement>e.currentTarget;
     target.setAttribute("readonly", "true");
+    this._updateFragmentTitle();
   }
 
   private _updateFragmentTitle() {

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -1,8 +1,8 @@
 import { LitElement, html, TemplateResult, css } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import { live } from "lit/directives/live.js";
-import { Fragment } from "models.d";
 import { dispatch } from "../events/dispatcher";
+import { Fragment } from "models.d";
 
 const { myAPI } = window;
 
@@ -16,7 +16,6 @@ export class FragmentTitle extends LitElement {
       :host {
         width: 100%;
       }
-
       input {
         background-color: transparent;
         color: white;

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -1,16 +1,18 @@
 import { LitElement, html, TemplateResult, css } from "lit";
-import { customElement, property, query } from "lit/decorators.js";
+import { customElement, property, query, state } from "lit/decorators.js";
+import { live } from "lit/directives/live.js";
+import { Fragment } from "models.d";
 import { dispatch } from "../events/dispatcher";
 
 @customElement("fragment-title")
 export class FragmentTitle extends LitElement {
   @query("input") private inputElement!: HTMLInputElement;
   @property({ type: String })
-  initialValue!: string;
-  @property({ type: String })
   title = "";
   @property({ type: Number })
   fragmentId!: number;
+  @property({ type: Object }) fragment!: Fragment;
+  @state() editable = false;
 
   static styles = [
     css`
@@ -36,7 +38,7 @@ export class FragmentTitle extends LitElement {
     return html`
       <input
         type="text"
-        value="${this.title}"
+        .value=${live(this.fragment.title) || "untitled"}
         placeholder="untitled"
         readonly
         @dblclick="${this._enableEdit}"
@@ -48,7 +50,6 @@ export class FragmentTitle extends LitElement {
 
   private _enableEdit(e: MouseEvent) {
     const target = <HTMLInputElement>e.currentTarget;
-    this.initialValue = this.inputElement.value;
     target.removeAttribute("readonly");
     target.select();
   }
@@ -61,7 +62,7 @@ export class FragmentTitle extends LitElement {
         this._titleChanged();
       }
       if (e.key === "Escape") {
-        target.value = this.initialValue;
+        target.value = this.fragment.title;
         target.setAttribute("readonly", "true");
         this._titleChanged();
       }
@@ -77,7 +78,7 @@ export class FragmentTitle extends LitElement {
     dispatch({
       type: "fragment-title-changed",
       detail: {
-        fragmentId: this.fragmentId,
+        fragmentId: this.fragment._id,
         title: this.inputElement.value,
       },
     });

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -65,7 +65,6 @@ export class FragmentTitle extends LitElement {
       if (e.key === "Enter") {
         target.setAttribute("readonly", "true");
         this._updateFragmentTitle();
-        this._titleChanged();
       }
       if (e.key === "Escape") {
         target.value = this.fragment.title;
@@ -93,15 +92,5 @@ export class FragmentTitle extends LitElement {
           type: "update-snippets",
         });
       });
-  }
-
-  private _titleChanged() {
-    dispatch({
-      type: "fragment-title-changed",
-      detail: {
-        fragmentId: this.fragment._id,
-        title: this.inputElement.value,
-      },
-    });
   }
 }

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -4,6 +4,8 @@ import { live } from "lit/directives/live.js";
 import { Fragment } from "models.d";
 import { dispatch } from "../events/dispatcher";
 
+const { myAPI } = window;
+
 @customElement("fragment-title")
 export class FragmentTitle extends LitElement {
   @query("input") private inputElement!: HTMLInputElement;
@@ -62,12 +64,12 @@ export class FragmentTitle extends LitElement {
     if (!e.isComposing) {
       if (e.key === "Enter") {
         target.setAttribute("readonly", "true");
+        this._updateFragmentTitle();
         this._titleChanged();
       }
       if (e.key === "Escape") {
         target.value = this.fragment.title;
         target.setAttribute("readonly", "true");
-        this._titleChanged();
       }
     }
   }
@@ -75,6 +77,21 @@ export class FragmentTitle extends LitElement {
   private _disableEditOnBlur(e: FocusEvent) {
     const target = <HTMLInputElement>e.currentTarget;
     target.setAttribute("readonly", "true");
+  }
+
+  private _updateFragmentTitle() {
+    myAPI
+      .updateFragment({
+        _id: this.fragment._id,
+        properties: {
+          title: this.inputElement.value,
+        },
+      })
+      .then(() => {
+        dispatch({
+          type: "update-snippets",
+        });
+      });
   }
 
   private _titleChanged() {

--- a/src/controllers/fragments-controller.ts
+++ b/src/controllers/fragments-controller.ts
@@ -24,10 +24,6 @@ export class FragmentsController implements ReactiveController {
       this._selectSnippetListener as EventListener
     );
     window.addEventListener(
-      "fragment-title-changed",
-      this._titleChangedListener as EventListener
-    );
-    window.addEventListener(
       "active-fragment",
       this._activeFragmentListener as EventListener
     );
@@ -47,12 +43,6 @@ export class FragmentsController implements ReactiveController {
       });
     });
   }
-
-  private _titleChangedListener = (e: CustomEvent) => {
-    const { fragmentId, title } = e.detail;
-    console.info("title changed", fragmentId, title);
-    // update the fragments
-  };
 
   private _selectSnippetListener = (e: CustomEvent): void => {
     this.snippet = JSON.parse(e.detail.selectedSnippet);

--- a/src/props.d.ts
+++ b/src/props.d.ts
@@ -10,6 +10,7 @@ export interface ISnippetProps {
 export interface IFragmentProps {
   _id?: number;
   properties: {
+    title?: string;
     content?: string;
     language?: Partial<Language>;
   };


### PR DESCRIPTION
- Render fragment-title in fragment-tab
- Tweak placeholder
- Set width: 100% on fragment-title and its input
- Update fragment title on enter
- Update fragment title on blur
- Remove "fragment-title-changed" event
- Remove title and state properties
- Cleanup
