### PR TITLE
search snippets by title

### DIFF
--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -127,6 +127,10 @@ export class FragmentTabList extends LitElement {
         .deleteFragment(this._idsOnDeleteFragment(this.tabOnContext))
         .then(() => {
           dispatch({
+            type: "clear-search-snippets",
+          });
+
+          dispatch({
             type: "update-snippets",
           });
         });

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -127,7 +127,7 @@ export class FragmentTabList extends LitElement {
         .deleteFragment(this._idsOnDeleteFragment(this.tabOnContext))
         .then(() => {
           dispatch({
-            type: "clear-search-snippets",
+            type: "clear-internal-search-query",
           });
 
           dispatch({

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -43,7 +43,7 @@ export class FragmentTitle extends LitElement {
         placeholder="untitled"
         readonly
         @dblclick="${this._enableEdit}"
-        @keydown="${this._disableEditOnEnter}"
+        @keydown="${this._disableEdit}"
         @blur="${this._disableEditOnBlur}"
       />
     `;
@@ -55,7 +55,7 @@ export class FragmentTitle extends LitElement {
     target.select();
   }
 
-  private _disableEditOnEnter(e: KeyboardEvent) {
+  private _disableEdit(e: KeyboardEvent) {
     const target = <HTMLInputElement>e.currentTarget;
     if (!e.isComposing) {
       if (e.key === "Enter") {

--- a/src/components/fragment-title.ts
+++ b/src/components/fragment-title.ts
@@ -71,8 +71,8 @@ export class FragmentTitle extends LitElement {
 
   private _disableEditOnBlur(e: FocusEvent) {
     const target = <HTMLInputElement>e.currentTarget;
+    target.value = this.fragment.title;
     target.setAttribute("readonly", "true");
-    this._updateFragmentTitle();
   }
 
   private _updateFragmentTitle() {

--- a/src/components/search-item.ts
+++ b/src/components/search-item.ts
@@ -32,6 +32,7 @@ export class SearchItem extends LitElement {
           inputmode="search"
           clearable
           @input="${this._search}"
+          @keydown="${this._searchByEnter}"
           @compositionend="${this._search}"
           @sl-clear="${this._clear}"
         ></sl-input>
@@ -42,6 +43,21 @@ export class SearchItem extends LitElement {
   private _search = (e: InputEvent): void => {
     const target = <HTMLInputElement>e.currentTarget;
     if (e.isComposing) return;
+
+    dispatch({
+      type: "search-snippets",
+      detail: {
+        query: target.value,
+      },
+    });
+  };
+
+  private _searchByEnter = (e: KeyboardEvent): void => {
+    if (e.key !== "Enter" || e.isComposing) return;
+
+    const target = <HTMLInputElement>e.currentTarget;
+
+    if (!target.value) return;
 
     dispatch({
       type: "search-snippets",

--- a/src/components/search-item.ts
+++ b/src/components/search-item.ts
@@ -69,7 +69,7 @@ export class SearchItem extends LitElement {
 
   private _clear = (e: Event): void => {
     dispatch({
-      type: "clear-search-snippets",
+      type: "clear-internal-search-query",
     });
 
     dispatch({

--- a/src/components/search-item.ts
+++ b/src/components/search-item.ts
@@ -26,7 +26,7 @@ export class SearchItem extends LitElement {
       <header>
         <sl-input
           id="search"
-          placeholder="Search..."
+          placeholder="Input or press enter..."
           size="large"
           type="search"
           inputmode="search"

--- a/src/components/search-item.ts
+++ b/src/components/search-item.ts
@@ -1,3 +1,4 @@
+import { dispatch } from "../events/dispatcher";
 import { LitElement, html, css, TemplateResult } from "lit";
 import { customElement } from "lit/decorators.js";
 
@@ -30,19 +31,33 @@ export class SearchItem extends LitElement {
           type="search"
           inputmode="search"
           clearable
-          @sl-input="${this._search}"
+          @input="${this._search}"
+          @compositionend="${this._search}"
           @sl-clear="${this._clear}"
         ></sl-input>
       </header>
     `;
   }
 
-  private _search = (e: Event): void => {
+  private _search = (e: InputEvent): void => {
     const target = <HTMLInputElement>e.currentTarget;
-    console.log("search:", target.value);
+    if (e.isComposing) return;
+
+    dispatch({
+      type: "search-snippets",
+      detail: {
+        query: target.value,
+      },
+    });
   };
 
   private _clear = (e: Event): void => {
-    console.log("Clear:", e);
+    dispatch({
+      type: "clear-search-snippets",
+    });
+
+    dispatch({
+      type: "update-snippets",
+    });
   };
 }

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -96,7 +96,7 @@ export class SnippetList extends LitElement {
   }
 
   updated(): void {
-    if (!this.snippetItems[0] || this.setupStorage.searching) return;
+    if (!this.snippetItems[0]) return;
     console.info(
       "snippet-list:updated",
       this.setupStorage.activeSnippetHistory
@@ -112,6 +112,7 @@ export class SnippetList extends LitElement {
           this.setupStorage.activeSnippetHistory.snippetId
       )!;
     }
+    if (!topItem) return;
 
     this._updateSelectedItem(topItem);
   }

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -129,7 +129,7 @@ export class SnippetList extends LitElement {
   private _contextMenuCommand(e: Event, command: string): void {
     if (command === "delete-snippet") {
       if (this.snippetItems.length <= 1) {
-        alert("You can't delete the last snippet");
+        alert("You can't delete the last snippet in the list");
       } else {
         const message = `Are you sure you want to delete "${this.snippet.title}"?`;
         if (confirm(message)) {

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -135,6 +135,10 @@ export class SnippetList extends LitElement {
         if (confirm(message)) {
           myAPI.deleteSnippet(this.snippet._id).then(() => {
             dispatch({
+              type: "clear-internal-search-query",
+            });
+
+            dispatch({
               type: "update-snippets",
             });
           });

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -77,8 +77,7 @@ export class SnippetList extends LitElement {
       this.snippet = JSON.parse(
         e.detail.selectedItems[0].getAttribute("snippet")
       );
-
-      const previouslySelectedSnippet = e.detail.previouslySelectedItems
+      const previouslySelectedSnippet = e.detail.previouslySelectedItems?.[0]
         ? e.detail.previouslySelectedItems[0].getAttribute("snippet")
         : null;
 
@@ -97,7 +96,7 @@ export class SnippetList extends LitElement {
   }
 
   updated(): void {
-    if (!this.snippetItems[0]) return;
+    if (!this.snippetItems[0] || this.setupStorage.searching) return;
     console.info(
       "snippet-list:updated",
       this.setupStorage.activeSnippetHistory

--- a/src/controllers/fragments-controller.ts
+++ b/src/controllers/fragments-controller.ts
@@ -36,7 +36,7 @@ export class FragmentsController implements ReactiveController {
 
     myAPI.initFragment(this.snippet._id).then(() => {
       dispatch({
-        type: "clear-search-snippets",
+        type: "clear-internal-search-query",
       });
 
       dispatch({

--- a/src/controllers/fragments-controller.ts
+++ b/src/controllers/fragments-controller.ts
@@ -36,6 +36,10 @@ export class FragmentsController implements ReactiveController {
 
     myAPI.initFragment(this.snippet._id).then(() => {
       dispatch({
+        type: "clear-search-snippets",
+      });
+
+      dispatch({
         type: "update-snippets",
       });
     });

--- a/src/controllers/is-searching-controller.ts
+++ b/src/controllers/is-searching-controller.ts
@@ -2,6 +2,7 @@ import { ReactiveController, ReactiveControllerHost } from "lit";
 
 export class IsSearchingController implements ReactiveController {
   isSearching = false;
+  query = "";
 
   constructor(host: ReactiveControllerHost) {
     host.addController(this);
@@ -24,9 +25,11 @@ export class IsSearchingController implements ReactiveController {
 
   private _searchSnippetsListener = (e: CustomEvent) => {
     this.isSearching = true;
+    this.query = e.detail.query;
   };
 
   private _clearSearchSnippetsListener = (e: CustomEvent) => {
     this.isSearching = false;
+    this.query = "";
   };
 }

--- a/src/controllers/is-searching-controller.ts
+++ b/src/controllers/is-searching-controller.ts
@@ -1,0 +1,32 @@
+import { ReactiveController, ReactiveControllerHost } from "lit";
+
+export class IsSearchingController implements ReactiveController {
+  isSearching = false;
+
+  constructor(host: ReactiveControllerHost) {
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    window.addEventListener(
+      "search-snippets",
+      this._searchSnippetsListener as EventListener
+    );
+    window.addEventListener(
+      "clear-search-snippets",
+      this._clearSearchSnippetsListener as EventListener
+    );
+  }
+
+  get searching() {
+    return this.isSearching;
+  }
+
+  private _searchSnippetsListener = (e: CustomEvent) => {
+    this.isSearching = true;
+  };
+
+  private _clearSearchSnippetsListener = (e: CustomEvent) => {
+    this.isSearching = false;
+  };
+}

--- a/src/controllers/search-query-controller.ts
+++ b/src/controllers/search-query-controller.ts
@@ -13,8 +13,8 @@ export class SearchQueryController implements ReactiveController {
       this._searchSnippetsListener as EventListener
     );
     window.addEventListener(
-      "clear-search-snippets",
-      this._clearSearchSnippetsListener as EventListener
+      "clear-internal-search-query",
+      this._clearSearchQuery as EventListener
     );
   }
 
@@ -22,7 +22,7 @@ export class SearchQueryController implements ReactiveController {
     this.query = e.detail.query;
   };
 
-  private _clearSearchSnippetsListener = (e: CustomEvent) => {
+  private _clearSearchQuery = (e: CustomEvent) => {
     this.query = "";
   };
 }

--- a/src/controllers/search-query-controller.ts
+++ b/src/controllers/search-query-controller.ts
@@ -10,7 +10,7 @@ export class SearchQueryController implements ReactiveController {
   hostConnected(): void {
     window.addEventListener(
       "search-snippets",
-      this._searchSnippetsListener as EventListener
+      this._searchSnippets as EventListener
     );
     window.addEventListener(
       "clear-internal-search-query",
@@ -18,7 +18,7 @@ export class SearchQueryController implements ReactiveController {
     );
   }
 
-  private _searchSnippetsListener = (e: CustomEvent) => {
+  private _searchSnippets = (e: CustomEvent) => {
     this.query = e.detail.query;
   };
 

--- a/src/controllers/search-query-controller.ts
+++ b/src/controllers/search-query-controller.ts
@@ -1,7 +1,6 @@
 import { ReactiveController, ReactiveControllerHost } from "lit";
 
-export class IsSearchingController implements ReactiveController {
-  isSearching = false;
+export class SearchQueryController implements ReactiveController {
   query = "";
 
   constructor(host: ReactiveControllerHost) {
@@ -19,17 +18,11 @@ export class IsSearchingController implements ReactiveController {
     );
   }
 
-  get searching() {
-    return this.isSearching;
-  }
-
   private _searchSnippetsListener = (e: CustomEvent) => {
-    this.isSearching = true;
     this.query = e.detail.query;
   };
 
   private _clearSearchSnippetsListener = (e: CustomEvent) => {
-    this.isSearching = false;
     this.query = "";
   };
 }

--- a/src/controllers/setup-storage-controller.ts
+++ b/src/controllers/setup-storage-controller.ts
@@ -82,7 +82,7 @@ export class SetupStorageController implements ReactiveController {
   private _initSnippet() {
     myAPI.initSnippet().then((snippet) => {
       myAPI.newActiveSnippetHistory(snippet._id);
-      this._loadSnippets(this.searchQuery.query, [snippet]);
+      this._loadSnippets();
     });
   }
 

--- a/src/controllers/setup-storage-controller.ts
+++ b/src/controllers/setup-storage-controller.ts
@@ -1,16 +1,19 @@
 import { displayToast } from "../displayToast";
 import { ReactiveController, ReactiveControllerHost } from "lit";
 import { Snippet, ActiveSnippetHistory } from "../models";
+import { IsSearchingController } from "./is-searching-controller";
 const { myAPI } = window;
 
 export class SetupStorageController implements ReactiveController {
   private host: ReactiveControllerHost;
+  isSearching: IsSearchingController;
 
   snippets: Snippet[] = [];
   activeSnippetHistory!: ActiveSnippetHistory;
 
   constructor(host: ReactiveControllerHost) {
     this.host = host;
+    this.isSearching = new IsSearchingController(host);
     host.addController(this);
   }
 
@@ -21,8 +24,16 @@ export class SetupStorageController implements ReactiveController {
       "update-snippets",
       this._updateSnippetsListener as EventListener
     );
+    window.addEventListener(
+      "search-snippets",
+      this._searchSnippetsListener as EventListener
+    );
     // When Command or Control + N is pressed
     myAPI.newSnippet((_e: Event) => this._initSnippet());
+  }
+
+  get searching() {
+    return this.isSearching.searching;
   }
 
   async setupStorage(): Promise<void> {
@@ -66,6 +77,8 @@ export class SetupStorageController implements ReactiveController {
   }
 
   private _updateSnippetsListener = (e: CustomEvent) => {
+    if (this.isSearching.searching) return;
+
     this._loadSnippets();
   };
 
@@ -75,4 +88,22 @@ export class SetupStorageController implements ReactiveController {
       this._loadSnippets();
     });
   }
+
+  private _searchSnippetsListener = (e: CustomEvent) => {
+    const query = e.detail.query;
+
+    if (!e.detail.query) {
+      myAPI.loadSnippets().then((snippets) => {
+        this.snippets = snippets;
+        this.host.requestUpdate();
+      });
+    } else {
+      myAPI.loadSnippets().then((snippets) => {
+        this.snippets = snippets.filter((snippet) =>
+          snippet.title.includes(query)
+        );
+        this.host.requestUpdate();
+      });
+    }
+  };
 }


### PR DESCRIPTION
- Search snippets by title
- Do not call _updateSelectedItem() when topItem is undefined
- Add query property to IsSearchingController
- Pass query to _loadSnippets()
- Tweak a message to delete a snippet
- Clear search query and update snippets
- Do not update a fragment title on blur
- Rename _disableEditOnEnter() to _disableEdit()
- Enable to search by enter
- Rename event name and its listener
- Rename event handler
- Clear search query and update snippets when deleting a snippet
- Rewrite placeholder on a search field
