### PR TITLE
clear search on creating new snippet

### DIFF
--- a/src/components/search-item.ts
+++ b/src/components/search-item.ts
@@ -1,9 +1,11 @@
 import { dispatch } from "../events/dispatcher";
 import { LitElement, html, css, TemplateResult } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, query } from "lit/decorators.js";
 
 @customElement("search-item")
 export class SearchItem extends LitElement {
+  @query("#search-input") searchInput!: HTMLInputElement;
+
   // Get rid of border on sl-input
   static styles = [
     css`
@@ -25,7 +27,7 @@ export class SearchItem extends LitElement {
     return html`
       <header>
         <sl-input
-          id="search"
+          id="search-input"
           placeholder="Input or press enter..."
           size="large"
           type="search"
@@ -39,6 +41,30 @@ export class SearchItem extends LitElement {
       </header>
     `;
   }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    window.addEventListener(
+      "snippets-created",
+      this._clearSearch as EventListener
+    );
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+  }
+
+  private _clearSearch = (_e: InputEvent): void => {
+    this.searchInput.value = "";
+    dispatch({
+      type: "clear-internal-search-query",
+    });
+
+    dispatch({
+      type: "update-snippets",
+    });
+  };
 
   private _search = (e: InputEvent): void => {
     const target = <HTMLInputElement>e.currentTarget;

--- a/src/components/search-item.ts
+++ b/src/components/search-item.ts
@@ -55,17 +55,6 @@ export class SearchItem extends LitElement {
     super.disconnectedCallback();
   }
 
-  private _clearSearch = (_e: InputEvent): void => {
-    this.searchInput.value = "";
-    dispatch({
-      type: "clear-internal-search-query",
-    });
-
-    dispatch({
-      type: "update-snippets",
-    });
-  };
-
   private _search = (e: InputEvent): void => {
     const target = <HTMLInputElement>e.currentTarget;
     if (e.isComposing) return;
@@ -101,5 +90,10 @@ export class SearchItem extends LitElement {
     dispatch({
       type: "update-snippets",
     });
+  };
+
+  private _clearSearch = (_e: InputEvent): void => {
+    this.searchInput.value = "";
+    this.searchInput.dispatchEvent(new CustomEvent("sl-clear"));
   };
 }

--- a/src/components/search-item.ts
+++ b/src/components/search-item.ts
@@ -4,7 +4,7 @@ import { customElement, query } from "lit/decorators.js";
 
 @customElement("search-item")
 export class SearchItem extends LitElement {
-  @query("#search-input") searchInput!: HTMLInputElement;
+  @query("#search-item") searchItem!: HTMLInputElement;
 
   // Get rid of border on sl-input
   static styles = [
@@ -27,7 +27,7 @@ export class SearchItem extends LitElement {
     return html`
       <header>
         <sl-input
-          id="search-input"
+          id="search-item"
           placeholder="Input or press enter..."
           size="large"
           type="search"
@@ -93,7 +93,7 @@ export class SearchItem extends LitElement {
   };
 
   private _clearSearch = (_e: InputEvent): void => {
-    this.searchInput.value = "";
-    this.searchInput.dispatchEvent(new CustomEvent("sl-clear"));
+    this.searchItem.value = "";
+    this.searchItem.dispatchEvent(new CustomEvent("sl-clear"));
   };
 }

--- a/src/components/search-item.ts
+++ b/src/components/search-item.ts
@@ -52,6 +52,11 @@ export class SearchItem extends LitElement {
   }
 
   disconnectedCallback() {
+    window.removeEventListener(
+      "snippets-created",
+      this._clearSearch as EventListener
+    );
+
     super.disconnectedCallback();
   }
 

--- a/src/controllers/setup-storage-controller.ts
+++ b/src/controllers/setup-storage-controller.ts
@@ -95,6 +95,9 @@ export class SetupStorageController implements ReactiveController {
     myAPI.initSnippet().then((snippet) => {
       myAPI.newActiveSnippetHistory(snippet._id);
       this._loadSnippets();
+      dispatch({
+        type: "snippets-created",
+      });
     });
   }
 


### PR DESCRIPTION
- Clear search query on creating a new snippet
- Use sl-clear event on _clearSearch()
- Rename searchItem
