### PR TITLE
Fix duplicate a new fragment after fragment tab list is restored

### DIFF
--- a/main-process/preload.js
+++ b/main-process/preload.js
@@ -12,6 +12,7 @@ contextBridge.exposeInMainWorld("myAPI", {
   newFragment: (listener) => ipcRenderer.on("new-fragment", listener),
   contextMenuCommand: (listener) =>
     ipcRenderer.on("context-menu-command", listener),
+  removeAllListeners: (channel) => ipcRenderer.removeAllListeners(channel),
   // renderer process -> main process
   initSnippet: () => ipcRenderer.invoke("init-snippet"),
   initFragment: (snippetId) => ipcRenderer.invoke("init-fragment", snippetId),

--- a/src/controllers/fragments-controller.ts
+++ b/src/controllers/fragments-controller.ts
@@ -40,6 +40,7 @@ export class FragmentsController implements ReactiveController {
       "active-fragment",
       this._activeFragmentListener as EventListener
     );
+    myAPI.removeAllListeners("new-fragment");
   }
 
   private _initFragment() {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -33,6 +33,7 @@ export interface SandBox {
   contextMenuCommand: (
     listener: (_e: Event, command: string) => void
   ) => Electron.IpcRenderer;
+  removeAllListeners: (channel?: string) => Electron.IpcRenderer;
   // renderer process -> main process
   initSnippet: () => Promise<Snippet>;
   initFragment: (snippetId: number) => Promise<void>;


### PR DESCRIPTION
When no search results, the editor component was erased. fragment-tab-list disappeared with it, but when it was restored, myAPI.newFragment was registered again.
