### PR TITLE
remove api listeners on disconnected

### DIFF
--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -173,6 +173,8 @@ export class CodeEditor extends LitElement {
   }
 
   private _saveCurrentViewState(fragmentId: number) {
+    if (!fragmentId) return;
+
     const viewState = this.editor.saveViewState();
     this.viewStateStore.setPartialRow("states", `${fragmentId}`, {
       viewState: JSON.stringify(viewState),

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -139,6 +139,12 @@ export class CodeEditor extends LitElement {
     myAPI.saveFragment((_e: Event) => this._saveText());
   }
 
+  disconnectedCallback() {
+    myAPI.removeAllListeners("save-fragment");
+
+    super.disconnectedCallback();
+  }
+
   updated() {
     // switch snippets
     if (this.viewStatesController.isSnippetSwitched) {

--- a/src/components/fragment-tab-list.ts
+++ b/src/components/fragment-tab-list.ts
@@ -67,6 +67,14 @@ export class FragmentTabList extends LitElement {
     );
   }
 
+  disconnectedCallback() {
+    myAPI.removeAllListeners("next-tab");
+    myAPI.removeAllListeners("previous-tab");
+    myAPI.removeAllListeners("context-menu-command");
+
+    super.disconnectedCallback();
+  }
+
   updated(): void {
     if (this.fragmentsController.activeFragmentId) {
       this.dispatchEvent(

--- a/src/components/settings-element.ts
+++ b/src/components/settings-element.ts
@@ -34,6 +34,12 @@ export class SettingsElement extends LitElement {
     `;
   }
 
+  disconnectedCallback() {
+    myAPI.removeAllListeners("toggle-settings");
+
+    super.disconnectedCallback();
+  }
+
   private _toggleSettings(): void {
     if (this.drawer.open) {
       this._closeSettings();

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -88,6 +88,8 @@ export class SnippetList extends LitElement {
       this._onSelectionChange as EventListener
     );
 
+    myAPI.removeAllListeners("context-menu-command");
+
     super.disconnectedCallback();
   }
 

--- a/src/components/snippet-list.ts
+++ b/src/components/snippet-list.ts
@@ -76,10 +76,6 @@ export class SnippetList extends LitElement {
       "selection-change",
       this._onSelectionChange as EventListener
     );
-
-    myAPI.contextMenuCommand((_e: Event, command) =>
-      this._contextMenuCommand(_e, command)
-    );
   }
 
   disconnectedCallback() {
@@ -87,8 +83,6 @@ export class SnippetList extends LitElement {
       "selection-change",
       this._onSelectionChange as EventListener
     );
-
-    myAPI.removeAllListeners("context-menu-command");
 
     super.disconnectedCallback();
   }
@@ -111,6 +105,13 @@ export class SnippetList extends LitElement {
   };
 
   async updated(): Promise<void> {
+    // Once the snippet list is restored from being empty, contextMenuCommand listener could be dead
+    // So we need to remvoe and re-add it
+    myAPI.removeAllListeners("context-menu-command");
+    myAPI.contextMenuCommand((_e: Event, command) =>
+      this._contextMenuCommand(_e, command)
+    );
+
     if (!this.snippetItems[0]) return;
 
     this._activeSnippetHistory = await myAPI.getLatestActiveSnippetHistory();


### PR DESCRIPTION
- Early return in _saveCurrentViewState() when no fragmentId
- Remove API listeners on disconnected
- Avoid contextMenuCommand from being dead after the snippet list has been restored
