### PR TITLE
display no snippets selected over editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,9 @@
     <div class="split">
       <settings-element></settings-element>
       <snippet-list id="split-0"></snippet-list>
-      <home-element id="split-1"></home-element>
+      <home-element id="split-1">
+        <no-snippets-element slot="no-snippets"></no-snippets-element>
+      </home-element>
     </div>
   </body>
 </html>

--- a/src/components.ts
+++ b/src/components.ts
@@ -9,3 +9,4 @@ import "./components/fragment-tab";
 import "./components/fragment-tab-list";
 import "./components/fragment-title";
 import "./components/editing-state-icon";
+import "./components/no-snippets-element";

--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -1,6 +1,6 @@
 import { dispatch } from "../events/dispatcher";
 import { LitElement, html, css, TemplateResult, PropertyValues } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { customElement, query, state } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 import { createFragmentStore, Store } from "../stores";
 import { Language } from "models.d";
@@ -43,7 +43,6 @@ export class EditorElement extends LitElement {
   private _activeFragmentId?: number;
   @state() private _content = "";
   @state() private _language = "plaintext";
-  @state() private _noSnippets = false;
   private _languages!: Language[];
 
   static styles = [
@@ -84,10 +83,6 @@ export class EditorElement extends LitElement {
     `,
   ];
 
-  renderNoSnippets(): TemplateResult {
-    return html`<section class="no-snippet">No Snippet Selected</section>`;
-  }
-
   render(): TemplateResult {
     return html`
       <section>
@@ -119,43 +114,6 @@ export class EditorElement extends LitElement {
       </footer>
     `;
   }
-
-  firstUpdated() {
-    window.addEventListener(
-      "snippets-loaded",
-      this._setSnippets as EventListener
-    );
-  }
-
-  disconnectedCallback() {
-    window.removeEventListener(
-      "snippets-loaded",
-      this._setSnippets as EventListener
-    );
-
-    super.disconnectedCallback();
-  }
-
-  protected updated(_changedProperties: PropertyValues): void {
-    // _changeProperties has the previous values of the changed properties
-    // It means the value of _noSnippets turns from true to false
-    if (_changedProperties.get("_noSnippets")) {
-      if (!this._activeFragmentId) return;
-      myAPI.getFragment(<number>this._activeFragmentId).then((fragment) => {
-        dispatch({
-          type: "select-snippet",
-          detail: {
-            selectedSnippet: JSON.stringify(fragment.snippet),
-          },
-        });
-      });
-    }
-  }
-
-  private _setSnippets = (e: CustomEvent): void => {
-    this._noSnippets = e.detail.noSnippets;
-    this.requestUpdate();
-  };
 
   private _selectLanguage() {
     this.select?.focus();

--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -1,5 +1,5 @@
 import { dispatch } from "../events/dispatcher";
-import { LitElement, html, css, TemplateResult, PropertyValues } from "lit";
+import { LitElement, html, css, TemplateResult } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import { map } from "lit/directives/map.js";
 import { createFragmentStore, Store } from "../stores";

--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -89,37 +89,35 @@ export class EditorElement extends LitElement {
   }
 
   render(): TemplateResult {
-    return !this._noSnippets
-      ? html`
-          <section>
-            <test-header></test-header>
-            <fragment-tab-list
-              @fragment-activated=${this._onFragmentActivated}
-            ></fragment-tab-list>
-            <code-editor
-              code="${this._content}"
-              language="${this._language}"
-              @change-text=${this._changeText}
-              @save-text=${this._saveText}
-              @blur-editor=${this._onBlurEditor}
-            ></code-editor>
-          </section>
-          <footer>
-            <select
-              name="languages"
-              id="lang-select"
-              @change=${this._selectionChange}
-            >
-              ${map(this._languages, (l) => {
-                return html`<option _idx=${l._idx} value=${l.name}>
-                  ${l.alias}
-                </option>`;
-              })}
-            </select>
-            <editing-state-icon></editing-state-icon>
-          </footer>
-        `
-      : this.renderNoSnippets();
+    return html`
+      <section>
+        <test-header></test-header>
+        <fragment-tab-list
+          @fragment-activated=${this._onFragmentActivated}
+        ></fragment-tab-list>
+        <code-editor
+          code="${this._content}"
+          language="${this._language}"
+          @change-text=${this._changeText}
+          @save-text=${this._saveText}
+          @blur-editor=${this._onBlurEditor}
+        ></code-editor>
+      </section>
+      <footer>
+        <select
+          name="languages"
+          id="lang-select"
+          @change=${this._selectionChange}
+        >
+          ${map(this._languages, (l) => {
+            return html`<option _idx=${l._idx} value=${l.name}>
+              ${l.alias}
+            </option>`;
+          })}
+        </select>
+        <editing-state-icon></editing-state-icon>
+      </footer>
+    `;
   }
 
   firstUpdated() {

--- a/src/components/home-element.ts
+++ b/src/components/home-element.ts
@@ -1,9 +1,11 @@
 import { ToastStackController } from "../controllers/toast-stack-controller";
 import { LitElement, html, css, TemplateResult } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 
 @customElement("home-element")
 export class HomeElement extends LitElement {
+  @state() private _noSnippets = true;
+
   constructor() {
     super();
     new ToastStackController(this);
@@ -23,7 +25,33 @@ export class HomeElement extends LitElement {
     `,
   ];
 
-  render(): TemplateResult {
-    return html` <editor-element></editor-element> `;
+  renderNoSnippets(): TemplateResult {
+    return this._noSnippets ? html`<slot name="no-snippets"></slot>` : html``;
   }
+
+  render(): TemplateResult {
+    return html`${this.renderNoSnippets()}
+      <editor-element></editor-element> `;
+  }
+
+  firstUpdated() {
+    window.addEventListener(
+      "snippets-loaded",
+      this._setSnippets as EventListener
+    );
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener(
+      "snippets-loaded",
+      this._setSnippets as EventListener
+    );
+
+    super.disconnectedCallback();
+  }
+
+  private _setSnippets = (e: CustomEvent): void => {
+    this._noSnippets = e.detail.noSnippets;
+    this.requestUpdate();
+  };
 }

--- a/src/components/home-element.ts
+++ b/src/components/home-element.ts
@@ -4,7 +4,7 @@ import { customElement, state } from "lit/decorators.js";
 
 @customElement("home-element")
 export class HomeElement extends LitElement {
-  @state() private _noSnippets = true;
+  @state() private _noSnippets = false;
 
   constructor() {
     super();
@@ -52,6 +52,5 @@ export class HomeElement extends LitElement {
 
   private _setSnippets = (e: CustomEvent): void => {
     this._noSnippets = e.detail.noSnippets;
-    this.requestUpdate();
   };
 }

--- a/src/components/no-snippets-element.ts
+++ b/src/components/no-snippets-element.ts
@@ -1,0 +1,31 @@
+import { LitElement, html, css, TemplateResult } from "lit";
+import { customElement } from "lit/decorators.js";
+
+@customElement("no-snippets-element")
+export class NoSnippetsElement extends LitElement {
+  constructor() {
+    super();
+  }
+
+  static styles = [
+    css`
+      :host {
+        position: absolute;
+        z-index: 10000;
+        width: 100%;
+        height: 100vh;
+        background-color: var(--dark-gray);
+      }
+
+      .no-snippet {
+        color: var(--gray);
+        padding: calc(50vh) 0px;
+        text-align: center;
+      }
+    `,
+  ];
+
+  render(): TemplateResult {
+    return html`<section class="no-snippet">No Snippets Selected</section>`;
+  }
+}


### PR DESCRIPTION
- Display `No Snippets Selected` component over the editor
- Cleanup editor-element
- Remove this.requestUpdate() and change _noSnippets to false as default
