### PR TITLE
Set `/` to vite base option

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: process.env.ELECTRON == "true" ? "./" : ".",
+  base: process.env.ELECTRON == "true" ? "./" : "/",
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
the following warning message had shown:
 (!) invalid "base" option: .. The value can only be an absolute URL, ./, or an empty string.

cf. https://vitejs.dev/config/#base
