### PR TITLE
Refactor to restore window

### DIFF
--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -14,9 +14,8 @@ import * as dbHandlers from "./dbHandlers";
 const isDev = process.env.IS_DEV == "true" ? true : false;
 
 function createWindow() {
-  const data = getWindowData();
-  const { width, height, x, y } = data.window;
-  console.log("window created", data.window);
+  const { width, height, x, y } = getWindowData().window;
+  console.log("window created", { width, height, x, y });
 
   // Create the browser window.
   const mainWindow = new BrowserWindow({
@@ -50,7 +49,7 @@ function createWindow() {
   }
 
   mainWindow.on("resize", () => {
-    const updatedWindowSettings = {
+    const updatedWindowData = {
       window: {
         width: mainWindow.getSize()[0],
         height: mainWindow.getSize()[1],
@@ -59,11 +58,11 @@ function createWindow() {
       },
     };
 
-    setWindowData(updatedWindowSettings);
+    setWindowData(updatedWindowData);
   });
 
   mainWindow.on("move", () => {
-    const updatedWindowSettings = {
+    const updatedWindowData = {
       window: {
         width: mainWindow.getSize()[0],
         height: mainWindow.getSize()[1],
@@ -72,7 +71,7 @@ function createWindow() {
       },
     };
 
-    setWindowData(updatedWindowSettings);
+    setWindowData(updatedWindowData);
   });
 }
 

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -8,16 +8,10 @@ import {
   PopupOptions,
 } from "electron";
 import { createMenu } from "./createMenu";
-import initRestoreWindow from "./settings/restore/window";
-import { JsonStorage } from "./jsonStorage";
+import { restoreWindow } from "./settings/restore/window";
 import * as dbHandlers from "./dbHandlers";
 
 const isDev = process.env.IS_DEV == "true" ? true : false;
-// top-level await requires Compiler option 'module' of value 'nodenext' is unstable.
-let restoreWindow: JsonStorage;
-initRestoreWindow().then((storage) => {
-  restoreWindow = storage;
-});
 
 function createWindow() {
   type WindowDataType = {

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -8,22 +8,13 @@ import {
   PopupOptions,
 } from "electron";
 import { createMenu } from "./createMenu";
-import { restoreWindow } from "./settings/restore/window";
+import { getWindowData, setWindowData } from "./settings/restore/window";
 import * as dbHandlers from "./dbHandlers";
 
 const isDev = process.env.IS_DEV == "true" ? true : false;
 
 function createWindow() {
-  type WindowDataType = {
-    window: {
-      width: number;
-      height: number;
-      x: number;
-      y: number;
-    };
-  };
-
-  const data = <WindowDataType>restoreWindow.lib.getSync("window");
+  const data = getWindowData();
   const { width, height, x, y } = data.window;
   console.log("window created", data.window);
 
@@ -68,11 +59,7 @@ function createWindow() {
       },
     };
 
-    restoreWindow.lib.set("window", updatedWindowSettings, function (err) {
-      if (err) {
-        console.log(err);
-      }
-    });
+    setWindowData(updatedWindowSettings);
   });
 
   mainWindow.on("move", () => {
@@ -85,11 +72,7 @@ function createWindow() {
       },
     };
 
-    restoreWindow.lib.set("window", updatedWindowSettings, function (err) {
-      if (err) {
-        console.log(err);
-      }
-    });
+    setWindowData(updatedWindowSettings);
   });
 }
 

--- a/main-process/settings/restore/window.ts
+++ b/main-process/settings/restore/window.ts
@@ -41,10 +41,10 @@ type WindowDataType = {
   };
 };
 
-// top-level await requires Compiler option 'module' of value 'nodenext' is unstable.
 let getWindowData: () => WindowDataType;
 let setWindowData: (_: WindowDataType) => void;
 
+// top-level await requires Compiler option 'module' of value 'nodenext' is unstable.
 initRestoreWindow().then((storage) => {
   getWindowData = () => {
     return <WindowDataType>storage.lib.getSync("window");

--- a/main-process/settings/restore/window.ts
+++ b/main-process/settings/restore/window.ts
@@ -32,12 +32,6 @@ const initRestoreWindow = async (): Promise<JsonStorage> => {
   }
 };
 
-// top-level await requires Compiler option 'module' of value 'nodenext' is unstable.
-let restoreWindow: JsonStorage;
-initRestoreWindow().then((storage) => {
-  restoreWindow = storage;
-});
-
 type WindowDataType = {
   window: {
     width: number;
@@ -47,16 +41,23 @@ type WindowDataType = {
   };
 };
 
-const getWindowData = () => {
-  return <WindowDataType>restoreWindow.lib.getSync("window");
-};
+// top-level await requires Compiler option 'module' of value 'nodenext' is unstable.
+let restoreWindow: JsonStorage;
+let getWindowData: () => WindowDataType;
+let setWindowData: (_: WindowDataType) => void;
 
-const setWindowData = (data: WindowDataType) => {
-  restoreWindow.lib.set("window", data, function (err) {
-    if (err) {
-      console.log(err);
-    }
-  });
-};
+initRestoreWindow().then((storage) => {
+  restoreWindow = storage;
+  getWindowData = () => {
+    return <WindowDataType>restoreWindow.lib.getSync("window");
+  };
+  setWindowData = (data) => {
+    restoreWindow.lib.set("window", data, function (err) {
+      if (err) {
+        console.log(err);
+      }
+    });
+  };
+});
 
 export { getWindowData, setWindowData };

--- a/main-process/settings/restore/window.ts
+++ b/main-process/settings/restore/window.ts
@@ -42,17 +42,15 @@ type WindowDataType = {
 };
 
 // top-level await requires Compiler option 'module' of value 'nodenext' is unstable.
-let restoreWindow: JsonStorage;
 let getWindowData: () => WindowDataType;
 let setWindowData: (_: WindowDataType) => void;
 
 initRestoreWindow().then((storage) => {
-  restoreWindow = storage;
   getWindowData = () => {
-    return <WindowDataType>restoreWindow.lib.getSync("window");
+    return <WindowDataType>storage.lib.getSync("window");
   };
   setWindowData = (data) => {
-    restoreWindow.lib.set("window", data, function (err) {
+    storage.lib.set("window", data, function (err) {
       if (err) {
         console.log(err);
       }

--- a/main-process/settings/restore/window.ts
+++ b/main-process/settings/restore/window.ts
@@ -6,7 +6,7 @@ import { JsonStorage, DatapathDoesNotExistError } from "../../jsonStorage";
 
 const pathToRestore = `${app.getPath("userData")}/fragmemoSettings/restore`;
 
-export default async (): Promise<JsonStorage> => {
+const initRestoreWindow = async (): Promise<JsonStorage> => {
   try {
     return new JsonStorage(pathToRestore);
   } catch (error) {
@@ -31,3 +31,11 @@ export default async (): Promise<JsonStorage> => {
     await setTimeout(1);
   }
 };
+
+// top-level await requires Compiler option 'module' of value 'nodenext' is unstable.
+let restoreWindow: JsonStorage;
+initRestoreWindow().then((storage) => {
+  restoreWindow = storage;
+});
+
+export { restoreWindow };

--- a/main-process/settings/restore/window.ts
+++ b/main-process/settings/restore/window.ts
@@ -38,4 +38,25 @@ initRestoreWindow().then((storage) => {
   restoreWindow = storage;
 });
 
-export { restoreWindow };
+type WindowDataType = {
+  window: {
+    width: number;
+    height: number;
+    x: number;
+    y: number;
+  };
+};
+
+const getWindowData = () => {
+  return <WindowDataType>restoreWindow.lib.getSync("window");
+};
+
+const setWindowData = (data: WindowDataType) => {
+  restoreWindow.lib.set("window", data, function (err) {
+    if (err) {
+      console.log(err);
+    }
+  });
+};
+
+export { getWindowData, setWindowData };

--- a/main-process/settings/restore/window.ts
+++ b/main-process/settings/restore/window.ts
@@ -20,7 +20,7 @@ const initRestoreWindow = async (): Promise<JsonStorage> => {
       // github.dev/electron-userland/electron-json-storage/blob/df4edce1e643e7343d962721fe2eacfeda094870/lib/storage.js#L419-L439
       fs.writeFileSync(
         path.resolve(pathToRestore, "window.json"),
-        JSON.stringify(defaultWindowSettings)
+        JSON.stringify(defaultWindowSettings, null, 2)
       );
       return new JsonStorage(pathToRestore);
     } else {
@@ -50,7 +50,7 @@ initRestoreWindow().then((storage) => {
     return <WindowDataType>storage.lib.getSync("window");
   };
   setWindowData = (data) => {
-    storage.lib.set("window", data, function (err) {
+    storage.lib.set("window", data, { prettyPrinting: true }, function (err) {
       if (err) {
         console.log(err);
       }


### PR DESCRIPTION
- Init JsonStorage and export it
- Export getter and setter for window data
- Rename updatedWindowSettings to updatedWindowData
- Define getter and setter for window data in then() scope
- Inline restoreWindow with storage (JsonStorage instance)
- chore: move comment below
- Prettify JSON on writing to the JSON file
