### PR TITLE
Improve initialization to create restoreWindowStorage

### DIFF
--- a/main-process/jsonStorage.ts
+++ b/main-process/jsonStorage.ts
@@ -6,13 +6,13 @@ export default class JsonStorage {
   datapath: string;
 
   constructor(datapath: string) {
-    this.doesDatapathExist(datapath);
+    JsonStorage.doesDatapathExist(datapath);
     this.lib = storage;
     this.lib.setDataPath(datapath);
     this.datapath = this.lib.getDataPath();
   }
 
-  doesDatapathExist(filePath: fs.PathLike): void {
+  static doesDatapathExist(filePath: fs.PathLike): void {
     if (!fs.existsSync(filePath)) {
       throw new DatapathDoesNotExistError(`${filePath} does not exist`);
     }

--- a/main-process/settings/restore/window.ts
+++ b/main-process/settings/restore/window.ts
@@ -8,6 +8,8 @@ const pathToRestore = `${app.getPath("userData")}/fragmemoSettings/restore`;
 
 const initRestoreWindowStorage = async (): Promise<JsonStorage> => {
   try {
+    // Check whether window.json exists or not
+    JsonStorage.doesDatapathExist(path.resolve(pathToRestore, "window.json"));
     return Promise.resolve(new JsonStorage(pathToRestore));
   } catch (error) {
     if (error instanceof DatapathDoesNotExistError) {

--- a/main-process/settings/restore/window.ts
+++ b/main-process/settings/restore/window.ts
@@ -11,21 +11,30 @@ const initRestoreWindowStorage = async (): Promise<JsonStorage> => {
     return Promise.resolve(new JsonStorage(pathToRestore));
   } catch (error) {
     if (error instanceof DatapathDoesNotExistError) {
-      fs.mkdirSync(pathToRestore, { recursive: true });
-      const defaultWindowSettings = {
-        window: { width: 800, height: 600, x: 0, y: 0 },
-      };
-      // Use fs.writeFileSync instead of electron-json-storage set()
-      // electron-json-storage set() is async, so we need to wait for it to finish
-      // github.dev/electron-userland/electron-json-storage/blob/df4edce1e643e7343d962721fe2eacfeda094870/lib/storage.js#L419-L439
-      fs.writeFileSync(
-        path.resolve(pathToRestore, "window.json"),
-        JSON.stringify(defaultWindowSettings, null, 2)
-      );
+      await createDefaultWindowSettings();
       return Promise.resolve(new JsonStorage(pathToRestore));
     } else {
       return Promise.reject(error);
     }
+  }
+};
+
+const createDefaultWindowSettings = async (): Promise<void> => {
+  try {
+    fs.mkdirSync(pathToRestore, { recursive: true });
+    const defaultWindowSettings = {
+      window: { width: 800, height: 600, x: 0, y: 0 },
+    };
+    // Use fs.writeFileSync instead of electron-json-storage set()
+    // electron-json-storage set() is async, so we need to wait for it to finish
+    // github.dev/electron-userland/electron-json-storage/blob/df4edce1e643e7343d962721fe2eacfeda094870/lib/storage.js#L419-L439
+    fs.writeFileSync(
+      path.resolve(pathToRestore, "window.json"),
+      JSON.stringify(defaultWindowSettings, null, 2)
+    );
+  } catch (error) {
+    console.error(error);
+    throw error;
   } finally {
     // But, just in case, we'll wait for 1 millisecond :)
     await setTimeout(1);


### PR DESCRIPTION
- Rerun Promise, resolve or reject, from initRestoreWindowStorage
- Change doesDatapathExist to static function
- Extract createDefaultWindowSettings()
- Check whether window.json exists or not
