### PR TITLE
Refactor JSON file for settings

### DIFF
--- a/main-process/fragmemoSettings.d.ts
+++ b/main-process/fragmemoSettings.d.ts
@@ -1,6 +1,4 @@
 export type EditorSettingsType = {
-  editor: {
-    autosave: boolean;
-    afterDelay: number;
-  };
+  autosave: boolean;
+  afterDelay: number;
 };

--- a/main-process/fragmemoSettings/editor.ts
+++ b/main-process/fragmemoSettings/editor.ts
@@ -4,7 +4,8 @@ import { EditorSettingsType } from "fragmemoSettings.d";
 const keyname = "userSettingsEditor";
 const filename = `${keyname}.json`;
 const defaultSettings = {
-  editor: { autosave: true, afterDelay: 1000 },
+  autosave: true,
+  afterDelay: 1000,
 };
 
 let getEditorSettings: () => EditorSettingsType;

--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -198,7 +198,7 @@ app.once("browser-window-created", () => {
   });
 
   ipcMain.handle("get-editor-settings", (event) => {
-    return getEditorSettings().editor;
+    return getEditorSettings();
   });
 
   ipcMain.handle("set-editor-settings", (event, settings) => {
@@ -207,11 +207,6 @@ app.once("browser-window-created", () => {
 });
 
 app.on("will-quit", () => {
-  // it takes a few seconds to load the new editor settings
-  // so we'll call it at the end
-  const { autosave, afterDelay } = getEditorSettings().editor;
-  console.log("new editor settings", { autosave, afterDelay });
-
   dbHandlers.onWillQuit();
 });
 

--- a/src/components/settings-group.ts
+++ b/src/components/settings-group.ts
@@ -14,6 +14,8 @@ export class SettingsGroup extends LitElement {
   @query("sl-input[name='after-delay']") afterDelay!: HTMLInputElement;
   @queryAll("sl-input") inputs!: HTMLInputElement[];
   @query("form") form!: HTMLFormElement;
+  @query("#reload-page") reloadPage!: HTMLButtonElement;
+
   @state() settings!: EditorSettingsType;
 
   constructor() {
@@ -46,6 +48,16 @@ export class SettingsGroup extends LitElement {
             <br />
             <sl-button type="submit" variant="primary">Submit</sl-button>
           </form>
+          <sl-tooltip>
+            <div slot="content">
+              Restore settings<br />before submitting changes
+            </div>
+            <sl-icon-button
+              id="reload-page"
+              name="arrow-clockwise"
+              label="Reload"
+            ></sl-icon-button>
+          </sl-tooltip>
         </sl-tab-panel>
         <sl-tab-panel name="custom">This is the custom tab panel.</sl-tab-panel>
         <sl-tab-panel name="advanced"
@@ -70,13 +82,18 @@ export class SettingsGroup extends LitElement {
         });
       }
     });
+
+    this.reloadPage.addEventListener("click", () => {
+      this.requestUpdate();
+    });
   }
 
   updated() {
     if (!this.settings) return;
 
-    // ensure to update the `autosave` switch
+    // ensure to update the state of the inputs
     this.autosave.checked = this.settings.autosave;
+    this.afterDelay.valueAsNumber = this.settings.afterDelay;
   }
 
   private _setSettings() {

--- a/src/components/settings-group.ts
+++ b/src/components/settings-group.ts
@@ -75,6 +75,7 @@ export class SettingsGroup extends LitElement {
   updated() {
     if (!this.settings) return;
 
+    // ensure to update the `autosave` switch
     this.autosave.checked = this.settings.autosave;
   }
 

--- a/src/components/settings-group.ts
+++ b/src/components/settings-group.ts
@@ -11,14 +11,13 @@ export class SettingsGroup extends LitElement {
   @query("sl-input[name='after-delay']") afterDelay!: HTMLInputElement;
   @queryAll("sl-input") inputs!: HTMLInputElement[];
   @query("form") form!: HTMLFormElement;
-  @state() settings!: EditorSettingsType["editor"];
+  @state() settings!: EditorSettingsType;
 
   constructor() {
     super();
     myAPI.getEditorSettings().then((settings) => {
       this.settings = settings;
       this._settingsUpdated();
-      console.log("editor settings", this.settings);
     });
   }
 
@@ -31,12 +30,7 @@ export class SettingsGroup extends LitElement {
 
         <sl-tab-panel name="editor">
           <form>
-            <sl-switch
-              id="autosave"
-              name="autosave"
-              checked=${this.settings?.autosave}
-              >Auto save</sl-switch
-            >
+            <sl-switch id="autosave" name="autosave">Auto save</sl-switch>
             <sl-input
               type="number"
               placeholder="after delay (milliseconds)"
@@ -71,10 +65,16 @@ export class SettingsGroup extends LitElement {
     });
   }
 
+  updated() {
+    if (!this.settings) return;
+
+    this.autosave.checked = this.settings.autosave;
+  }
+
   private _setSettings() {
     this.settings.autosave = this.autosave.checked;
     this.settings.afterDelay = this.afterDelay.valueAsNumber;
-    myAPI.setEditorSettings({ editor: this.settings });
+    myAPI.setEditorSettings(this.settings);
   }
 
   private _settingsUpdated() {

--- a/src/components/settings-group.ts
+++ b/src/components/settings-group.ts
@@ -1,7 +1,10 @@
 import { EditorSettingsType } from "index.d";
 import { LitElement, html, TemplateResult } from "lit";
 import { customElement, query, queryAll, state } from "lit/decorators.js";
-import { userSettingsUpdated } from "../events/global-dispatchers";
+import {
+  userSettingsUpdated,
+  displayToast,
+} from "../events/global-dispatchers";
 
 const { myAPI } = window;
 
@@ -61,6 +64,10 @@ export class SettingsGroup extends LitElement {
       if (isAllValid) {
         this._setSettings();
         this._settingsUpdated();
+        displayToast("Editor settings updated", {
+          variant: "primary",
+          icon: "check2-circle",
+        });
       }
     });
   }
@@ -72,9 +79,12 @@ export class SettingsGroup extends LitElement {
   }
 
   private _setSettings() {
-    this.settings.autosave = this.autosave.checked;
-    this.settings.afterDelay = this.afterDelay.valueAsNumber;
-    myAPI.setEditorSettings(this.settings);
+    const updatedSettings = {
+      autosave: this.autosave.checked,
+      afterDelay: this.afterDelay.valueAsNumber,
+    };
+    myAPI.setEditorSettings(updatedSettings);
+    this.settings = updatedSettings;
   }
 
   private _settingsUpdated() {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -63,7 +63,7 @@ export interface SandBox {
   getFragment: (fragmentId: number) => Promise<Fragment>;
   getActiveFragment: (snippetId: number) => Promise<ActiveFragment>;
   getLatestActiveSnippetHistory: () => Promise<ActiveSnippetHistory>;
-  getEditorSettings: () => Promise<EditorSettingsType["editor"]>;
+  getEditorSettings: () => Promise<EditorSettingsType>;
   setEditorSettings: (settings: EditorSettingsType) => void;
   showContextMenuOnFragmentTab: () => void;
   showContextMenuOnSnippetItem: () => void;


### PR DESCRIPTION
- Remove `editor` key from fragmemoSettings
- Do not access `editor` key and set settings.autosave to the `autosave` switch element
- Display toast when updating the editor settings
- chore: add comment for updating the `autosave` switch element
- Add reload button to restore the current settings before submitting changes
