### PR TITLE
Set minWidth and minHeight of the screen

### DIFF
--- a/main-process/main.ts
+++ b/main-process/main.ts
@@ -23,6 +23,8 @@ function createWindow() {
 
   // Create the browser window.
   const mainWindow = new BrowserWindow({
+    minWidth: 400,
+    minHeight: 240 + 28, //the title bar height is 28px
     width: width,
     height: height,
     x: x,

--- a/src/split-pane.ts
+++ b/src/split-pane.ts
@@ -2,7 +2,9 @@ import Split from "split.js";
 
 Split(["#split-0", "#split-1"], {
   sizes: [25, 75],
-  minSize: 200,
+  // home-element width is 301.75px for the screen min width 400px
+  // so the offset width is 400 - 301.75 = 98.25
+  minSize: 98,
   gutterSize: 6,
   gutterAlign: "start",
   snapOffset: 0,


### PR DESCRIPTION
Split.js minSize is 98px to avoid breaking the layout on the boot with the min size of the screen
