### PR TITLE
Add top-level key `files` to user editor settings

### DIFF
--- a/main-process/fragmemoSettings.d.ts
+++ b/main-process/fragmemoSettings.d.ts
@@ -1,4 +1,6 @@
 export type EditorSettingsType = {
-  autosave: boolean;
-  afterDelay: number;
+  files: {
+    autosave: boolean;
+    afterDelay: number;
+  };
 };

--- a/main-process/fragmemoSettings/editor.ts
+++ b/main-process/fragmemoSettings/editor.ts
@@ -3,7 +3,7 @@ import { EditorSettingsType } from "fragmemoSettings.d";
 
 const keyname = "userSettingsEditor";
 const filename = `${keyname}.json`;
-const defaultSettings = {
+const defaultSettings: EditorSettingsType = {
   files: {
     autosave: true,
     afterDelay: 1000,

--- a/main-process/fragmemoSettings/editor.ts
+++ b/main-process/fragmemoSettings/editor.ts
@@ -4,8 +4,10 @@ import { EditorSettingsType } from "fragmemoSettings.d";
 const keyname = "userSettingsEditor";
 const filename = `${keyname}.json`;
 const defaultSettings = {
-  autosave: true,
-  afterDelay: 1000,
+  files: {
+    autosave: true,
+    afterDelay: 1000,
+  },
 };
 
 let getEditorSettings: () => EditorSettingsType;

--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -136,8 +136,8 @@ export class EditorElement extends LitElement {
   }
 
   private _onEditorSettingsUpdated = (e: CustomEvent) => {
-    this._autosave = e.detail.userSettings.autosave;
-    this._afterDelay = e.detail.userSettings.afterDelay;
+    this._autosave = e.detail.userSettings.files.autosave;
+    this._afterDelay = e.detail.userSettings.files.afterDelay;
   };
 
   private _selectLanguage() {

--- a/src/components/settings-editor.ts
+++ b/src/components/settings-editor.ts
@@ -52,7 +52,7 @@ export class SettingsEditor extends LitElement {
             type="number"
             placeholder="after delay (milliseconds)"
             size="small"
-            value=${this.settings?.afterDelay}
+            value=${this.settings?.files.afterDelay}
             min="1"
             name="after-delay"
             class="input"
@@ -100,14 +100,16 @@ export class SettingsEditor extends LitElement {
     if (!this.settings) return;
 
     // ensure to update the state of the inputs
-    this.autosave.checked = this.settings.autosave;
-    this.afterDelay.valueAsNumber = this.settings.afterDelay;
+    this.autosave.checked = this.settings.files.autosave;
+    this.afterDelay.valueAsNumber = this.settings.files.afterDelay;
   }
 
   private _setSettings() {
     const updatedSettings = {
-      autosave: this.autosave.checked,
-      afterDelay: this.afterDelay.valueAsNumber,
+      files: {
+        autosave: this.autosave.checked,
+        afterDelay: this.afterDelay.valueAsNumber,
+      },
     };
     myAPI.setEditorSettings(updatedSettings);
     this.settings = updatedSettings;


### PR DESCRIPTION
`files` settings are not monaco-editor's settings
