### PR TITLE
add editor settings

### DIFF
--- a/main-process/fragmemoSettings.d.ts
+++ b/main-process/fragmemoSettings.d.ts
@@ -1,4 +1,7 @@
 export type EditorSettingsType = {
+  editor: {
+    lineNumbers: "on" | "off" | "relative" | "interval";
+  };
   files: {
     autosave: boolean;
     afterDelay: number;

--- a/main-process/fragmemoSettings/editor.ts
+++ b/main-process/fragmemoSettings/editor.ts
@@ -4,6 +4,9 @@ import { EditorSettingsType } from "fragmemoSettings.d";
 const keyname = "userSettingsEditor";
 const filename = `${keyname}.json`;
 const defaultSettings: EditorSettingsType = {
+  editor: {
+    lineNumbers: "on",
+  },
   files: {
     autosave: true,
     afterDelay: 1000,

--- a/src/components/codeEditor.ts
+++ b/src/components/codeEditor.ts
@@ -44,6 +44,7 @@ export class CodeEditor extends LitElement {
   @property({ type: Boolean, attribute: "readonly" }) readOnly?: boolean;
   @property() language!: string;
   @property() code!: string;
+  @property({ type: Object }) editorOptions!: object;
 
   static styles = css`
     :host {
@@ -177,6 +178,10 @@ export class CodeEditor extends LitElement {
     console.log(`model language was changed to ${this.model.getLanguageId()}`);
     this.setValue(this.code);
 
+    if (!this._ObjectIsEmpty(this.editorOptions)) {
+      this.setOptions(this.editorOptions);
+    }
+
     console.info("updated", this.viewStateStore.getTable("states"));
     if (
       this.viewStateStore.hasRow(
@@ -187,6 +192,9 @@ export class CodeEditor extends LitElement {
       this._restoreCurrentViewState();
     }
   }
+
+  private _ObjectIsEmpty = (obj: object) =>
+    Object.keys(obj).length === 0 && obj.constructor === Object;
 
   private _selectLanguage(): void {
     this.dispatchEvent(new CustomEvent("select-language"));

--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -143,6 +143,7 @@ export class EditorElement extends LitElement {
   private _onEditorSettingsUpdated = (e: CustomEvent) => {
     this._autosave = e.detail.userSettings.files.autosave;
     this._afterDelay = e.detail.userSettings.files.afterDelay;
+    this._editorOptions = { ...e.detail.userSettings.editor };
   };
 
   private _selectLanguage() {

--- a/src/components/editor-element.ts
+++ b/src/components/editor-element.ts
@@ -36,6 +36,9 @@ export class EditorElement extends LitElement {
     myAPI.loadLanguages().then((languages) => {
       this._languages = languages;
     });
+    myAPI.getEditorSettings().then((settings) => {
+      this._editorOptions = { ...settings.editor };
+    });
   }
 
   @query("#lang-select") select?: HTMLSelectElement;
@@ -43,6 +46,7 @@ export class EditorElement extends LitElement {
   private _activeFragmentId?: number;
   @state() private _content = "";
   @state() private _language = "plaintext";
+  @state() private _editorOptions = {};
   private _languages!: Language[];
   @state() private _autosave!: boolean;
   private _afterDelay!: number;
@@ -95,6 +99,7 @@ export class EditorElement extends LitElement {
         <code-editor
           code="${this._content}"
           language="${this._language}"
+          editorOptions="${JSON.stringify(this._editorOptions)}"
           @change-text=${this._changeText}
           @save-content=${this._saveContent}
           @blur-editor=${this._onBlurEditor}

--- a/src/components/settings-editor.ts
+++ b/src/components/settings-editor.ts
@@ -14,6 +14,8 @@ const lineNumbersList = ["on", "off", "relative", "interval"] as const;
 export class SettingsEditor extends LitElement {
   @query("#autosave") autosave!: HTMLInputElement;
   @query("sl-input[name='after-delay']") afterDelay!: HTMLInputElement;
+  @query("sl-select[name='editor-line-numbers']")
+  editorLineNumbers!: HTMLInputElement;
   @queryAll("sl-input") inputs!: HTMLInputElement[];
   @query("form") form!: HTMLFormElement;
   @query("#reload-page") reloadPage!: HTMLButtonElement;
@@ -50,7 +52,10 @@ export class SettingsEditor extends LitElement {
       <div class="content-container">
         <form>
           <h2>Editor</h2>
-          <sl-select value=${this.settings?.editor?.lineNumbers}>
+          <sl-select
+            name="editor-line-numbers"
+            value=${this.settings?.editor?.lineNumbers}
+          >
             ${map(
               lineNumbersList,
               (i) => html`<sl-menu-item value=${i}>${i}</sl-menu-item>`
@@ -107,15 +112,17 @@ export class SettingsEditor extends LitElement {
   updated() {
     if (!this.settings) return;
 
-    // ensure to update the state of the inputs
+    // ensure to update the UI state of the inputs
     this.autosave.checked = this.settings.files.autosave;
     this.afterDelay.valueAsNumber = this.settings.files.afterDelay;
+    this.editorLineNumbers.value = this.settings.editor.lineNumbers;
   }
 
   private _setSettings() {
     const updatedSettings: EditorSettingsType = {
       editor: {
-        lineNumbers: "on", // TODO: set this.settings.editor.lineNumbers
+        lineNumbers: this.editorLineNumbers
+          .value as typeof lineNumbersList[number],
       },
       files: {
         autosave: this.autosave.checked,

--- a/src/components/settings-editor.ts
+++ b/src/components/settings-editor.ts
@@ -61,7 +61,12 @@ export class SettingsEditor extends LitElement {
               (i) => html`<sl-menu-item value=${i}>${i}</sl-menu-item>`
             )}
           </sl-select>
-          <sl-switch id="autosave" name="autosave">Auto save</sl-switch>
+          <sl-switch
+            id="autosave"
+            name="autosave"
+            ?checked="${this.settings?.files?.autosave}"
+            >Auto save</sl-switch
+          >
           <sl-input
             type="number"
             placeholder="after delay (milliseconds)"

--- a/src/components/settings-editor.ts
+++ b/src/components/settings-editor.ts
@@ -44,6 +44,12 @@ export class SettingsEditor extends LitElement {
         display: inline-flex;
         justify-content: space-between;
       }
+      sl-switch::part(base) {
+        color: var(--sl-input-label-color);
+      }
+      h3 {
+        margin-block: 0;
+      }
     `,
   ];
 
@@ -51,8 +57,10 @@ export class SettingsEditor extends LitElement {
     return html`
       <div class="content-container">
         <form>
-          <h2>Editor</h2>
+          <h3>Editor</h3>
           <sl-select
+            size="small"
+            label="Line Numbers"
             name="editor-line-numbers"
             value=${this.settings?.editor?.lineNumbers}
           >
@@ -61,6 +69,8 @@ export class SettingsEditor extends LitElement {
               (i) => html`<sl-menu-item value=${i}>${i}</sl-menu-item>`
             )}
           </sl-select>
+
+          <h3>Files</h3>
           <sl-switch
             id="autosave"
             name="autosave"
@@ -68,6 +78,7 @@ export class SettingsEditor extends LitElement {
             >Auto save</sl-switch
           >
           <sl-input
+            label="Auto Save Delay"
             type="number"
             placeholder="after delay (milliseconds)"
             size="small"

--- a/src/components/settings-editor.ts
+++ b/src/components/settings-editor.ts
@@ -1,12 +1,14 @@
 import { EditorSettingsType } from "index.d";
 import { LitElement, html, TemplateResult, css } from "lit";
 import { customElement, query, queryAll, state } from "lit/decorators.js";
+import { map } from "lit/directives/map.js";
 import {
   userSettingsUpdated,
   displayToast,
 } from "../events/global-dispatchers";
 
 const { myAPI } = window;
+const lineNumbersList = ["on", "off", "relative", "interval"] as const;
 
 @customElement("settings-editor")
 export class SettingsEditor extends LitElement {
@@ -47,6 +49,13 @@ export class SettingsEditor extends LitElement {
     return html`
       <div class="content-container">
         <form>
+          <h2>Editor</h2>
+          <sl-select value=${this.settings?.editor?.lineNumbers}>
+            ${map(
+              lineNumbersList,
+              (i) => html`<sl-menu-item value=${i}>${i}</sl-menu-item>`
+            )}
+          </sl-select>
           <sl-switch id="autosave" name="autosave">Auto save</sl-switch>
           <sl-input
             type="number"
@@ -104,7 +113,10 @@ export class SettingsEditor extends LitElement {
   }
 
   private _setSettings() {
-    const updatedSettings = {
+    const updatedSettings: EditorSettingsType = {
+      editor: {
+        lineNumbers: "on", // TODO: set this.settings.editor.lineNumbers
+      },
       files: {
         autosave: this.autosave.checked,
         afterDelay: this.afterDelay.valueAsNumber,


### PR DESCRIPTION
- Add property for EditorSettingsType and display a select for line numbers
- Update editor lineNumbers in JSON file
- Bind to `checked`, a boolean attribute
- Set monaco editor options at the first update on editor-element
- Set monaco editor options at updating the editor settings
- Adjust settings-editor layout
