### PR TITLE
use monaco editor options

### DIFF
--- a/main-process/fragmemoSettings.d.ts
+++ b/main-process/fragmemoSettings.d.ts
@@ -1,7 +1,7 @@
+import * as monaco from "monaco-editor";
+
 export type EditorSettingsType = {
-  editor: {
-    lineNumbers: "on" | "off" | "relative" | "interval";
-  };
+  editor: monaco.editor.IEditorOptions;
   files: {
     autosave: boolean;
     afterDelay: number;

--- a/src/components/settings-editor.ts
+++ b/src/components/settings-editor.ts
@@ -9,7 +9,9 @@ import {
 import * as monaco from "monaco-editor";
 
 const { myAPI } = window;
-const lineNumbersList = ["on", "off", "relative", "interval"] as const;
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const lineNumbersList = monaco.editor.EditorOptions.lineNumbers.schema.enum;
 
 @customElement("settings-editor")
 export class SettingsEditor extends LitElement {

--- a/src/components/settings-editor.ts
+++ b/src/components/settings-editor.ts
@@ -96,7 +96,10 @@ export class SettingsEditor extends LitElement {
           </div>
 
           <h3>Files</h3>
-          <div class="form-group">
+          <div
+            class="form-group"
+            ?customized="${!this.settings?.files?.autosave}"
+          >
             <sl-switch
               id="autosave"
               name="autosave"
@@ -104,7 +107,10 @@ export class SettingsEditor extends LitElement {
               >Auto save</sl-switch
             >
           </div>
-          <div class="form-group">
+          <div
+            class="form-group"
+            ?customized="${this.settings?.files?.afterDelay !== 1000}"
+          >
             <sl-input
               label="Auto Save Delay"
               type="number"

--- a/src/components/settings-editor.ts
+++ b/src/components/settings-editor.ts
@@ -31,7 +31,7 @@ export class SettingsEditor extends LitElement {
     const options = Object.entries(monaco.editor.EditorOptions).map(
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      ([_, value]) => [value.name, value.schema?.value ?? value.defaultValue]
+      ([_, value]) => [value.name, value.schema?.default ?? value.defaultValue]
     );
     console.log("object fromEntries", Object.fromEntries(options));
     this.defaultEditorOptions = Object.fromEntries(options);

--- a/src/components/settings-editor.ts
+++ b/src/components/settings-editor.ts
@@ -24,8 +24,7 @@ export class SettingsEditor extends LitElement {
   @query("#reload-page") reloadPage!: HTMLButtonElement;
 
   @state() settings!: EditorSettingsType;
-  defaultSettings: Partial<EditorSettingsType["editor"]>;
-  monacoEditorSettings!: EditorSettingsType["editor"];
+  defaultEditorOptions: Partial<EditorSettingsType["editor"]>;
 
   constructor() {
     super();
@@ -35,7 +34,7 @@ export class SettingsEditor extends LitElement {
       ([_, value]) => [value.name, value.schema?.value ?? value.defaultValue]
     );
     console.log("object fromEntries", Object.fromEntries(options));
-    this.defaultSettings = Object.fromEntries(options);
+    this.defaultEditorOptions = Object.fromEntries(options);
 
     myAPI.getEditorSettings().then((settings) => {
       // override default settings with user settings

--- a/src/components/settings-editor.ts
+++ b/src/components/settings-editor.ts
@@ -60,11 +60,15 @@ export class SettingsEditor extends LitElement {
       sl-switch::part(base) {
         color: var(--sl-input-label-color);
       }
-      sl-select {
-        border-left: 1px solid var(--sl-color-primary-600);
-      }
       h3 {
         margin-block: 0;
+      }
+      .form-group {
+        padding-left: 0.5rem;
+      }
+      .form-group[customized] {
+        padding-left: 0.5rem;
+        border-left: 1px solid var(--sl-color-primary-600);
       }
     `,
   ];
@@ -74,36 +78,45 @@ export class SettingsEditor extends LitElement {
       <div class="content-container">
         <form>
           <h3>Editor</h3>
-          <sl-select
-            size="small"
-            label="Line Numbers"
-            name="editor-line-numbers"
-            value=${this.settings?.editor?.lineNumbers}
+          <div
+            class="form-group"
+            ?customized="${this._isCustomized("lineNumbers")}"
           >
-            ${map(
-              lineNumbersList,
-              (i) => html`<sl-menu-item value=${i}>${i}</sl-menu-item>`
-            )}
-          </sl-select>
+            <sl-select
+              size="small"
+              label="Line Numbers"
+              name="editor-line-numbers"
+              value=${this.settings?.editor?.lineNumbers}
+            >
+              ${map(
+                lineNumbersList,
+                (i) => html`<sl-menu-item value=${i}>${i}</sl-menu-item>`
+              )}
+            </sl-select>
+          </div>
 
           <h3>Files</h3>
-          <sl-switch
-            id="autosave"
-            name="autosave"
-            ?checked="${this.settings?.files?.autosave}"
-            >Auto save</sl-switch
-          >
-          <sl-input
-            label="Auto Save Delay"
-            type="number"
-            placeholder="after delay (milliseconds)"
-            size="small"
-            value=${this.settings?.files?.afterDelay}
-            min="1"
-            name="after-delay"
-            class="input"
-            required
-          ></sl-input>
+          <div class="form-group">
+            <sl-switch
+              id="autosave"
+              name="autosave"
+              ?checked="${this.settings?.files?.autosave}"
+              >Auto save</sl-switch
+            >
+          </div>
+          <div class="form-group">
+            <sl-input
+              label="Auto Save Delay"
+              type="number"
+              placeholder="after delay (milliseconds)"
+              size="small"
+              value=${this.settings?.files?.afterDelay}
+              min="1"
+              name="after-delay"
+              class="input"
+              required
+            ></sl-input>
+          </div>
           <div class="btn-group">
             <sl-button type="submit" variant="primary">Submit</sl-button>
             <sl-tooltip placement="left">
@@ -167,5 +180,12 @@ export class SettingsEditor extends LitElement {
 
   private _settingsUpdated() {
     userSettingsUpdated("editor", this.settings);
+  }
+
+  private _isCustomized(editorOptionName: keyof EditorSettingsType["editor"]) {
+    return (
+      this.defaultEditorOptions[`${editorOptionName}`] !==
+      this.settings?.editor[`${editorOptionName}`]
+    );
   }
 }


### PR DESCRIPTION
- Use monaco.editor.EditorOptions for the default editor settings
- Type lineNumbersList with enum of monaco.editorEditorOptions.lineNumbers.schema
- Rename defaultSettings to defaultEditorOptions
- Fix schema.value with schema.default
- Display line by left side of the form group when the value is user-customized
- Display line by left side of the form group when the value is user-customized
