### PR TITLE
Fix a bug not to update fragment tabs on creating a new fragment

### DIFF
--- a/src/controllers/fragments-controller.ts
+++ b/src/controllers/fragments-controller.ts
@@ -58,9 +58,6 @@ export class FragmentsController implements ReactiveController {
   private _onSnippetSelected = (e: CustomEvent): void => {
     this.snippet = JSON.parse(e.detail.selectedSnippet);
     if (!this.snippet) return;
-    if (this.snippet._id === this.activeFragmentId) {
-      return;
-    }
 
     myAPI.newActiveSnippetHistory(<number>this.snippet._id);
 


### PR DESCRIPTION
after the initial app setup, fragment tabs are not updated when you create a new fragment

https://github.com/noriyotcp/fragmemo/commit/2d30fb7fac33b1a813291126a629fd6a9ae07979
on this commit, the early return is invoked if this.snippet.id === this.activeFragmentId (why compared these?)

Accidentally, Snippet ID and Fragment ID match at the first time (1 and 1), and an early return is invoked

removing this code does not seem to change the behavior of the app, showing `No Snippet Selected` on the editor when no snippet found on searching and so on
