### PR TITLE
Ignore workflow on main branch

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,8 +5,10 @@ name: Node.js CI
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
+    tags:
+      - "*"
   pull_request:
     types:
       - opened

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches-ignore:
       - main
-    tags:
-      - "*"
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Allow to run workflows when pushing a tag commit (at other branches)
