### PR TITLE
Ignore workflow on main branch

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,7 +5,7 @@ name: Node.js CI
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
   pull_request:
     types:


### PR DESCRIPTION
Allow to run workflows when pushing a tag commit (at other branches)
