### PR TITLE
Revert "Bump realm from 10.21.1 to 11.1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fast-json-patch": "^3.1.1",
     "lit": "^2.4.0",
     "monaco-editor": "^0.34.0",
-    "realm": "^11.1.0",
+    "realm": "^10.21.1",
     "split.js": "^1.6.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,19 +932,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@realm/common@^0.1.4":
+"@realm.io/common@^0.1.4":
   version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@realm/common/-/common-0.1.4.tgz#48ff628a22b27c61ba886caff395909632240927"
-  integrity sha512-bKpIRZIQ4ykribFi0igCwuvf7P4+Ex2XYKqDw1JDe6sCGAaPMwhazooyM6h32fUjtXRTbdAWH2S9JH8Xh/LrqQ==
-
-"@realm/network-transport@^0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@realm/network-transport/-/network-transport-0.7.2.tgz#167b85fd4744b66d9e37d096e1e9e2720d7abd26"
-  integrity sha512-IZ6yd+mGOYvSMVEVFf/v5qtZOi8bk4ZBxoj25GNQFyeFKxOs1WH+z4IDZscMC2GhQ4hdmI3Sg+RUEphimtHupQ==
-  dependencies:
-    "@realm/common" "^0.1.4"
-    abort-controller "^3.0.0"
-    node-fetch "^2.6.0"
+  resolved "https://registry.yarnpkg.com/@realm.io/common/-/common-0.1.4.tgz#d50ed1c91af1477695222ce04754a19a81336a54"
+  integrity sha512-+nI/fOa/G9idiZ7h9DVz5NmnrvVNI3AM/I0eB7vL/PxDCF8vH3vew8ZrWOSr08GT2bDliy1wB6IYRqezQ1H/Iw==
 
 "@sap-theming/theming-base-content@11.1.41":
   version "11.1.41"
@@ -4852,13 +4843,20 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-realm@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/realm/-/realm-11.1.0.tgz#e1085eb045bb7155907cdf9960e89e2573cab94d"
-  integrity sha512-E3ZYw6jUXPcl1wGtZuGtqI2z2j/hoCeuP9Mq6KDVqLdfxXzJGciZpgF1szG8KXmqgHOslQboKJkIJmjGhGUvxg==
+realm-network-transport@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/realm-network-transport/-/realm-network-transport-0.7.2.tgz#382b965bf97a4132e0f8770f864d4a20d976be35"
+  integrity sha512-/5/YtZ5+ZIHIPgVFL6fRyx0/FRhmMaaF7L/h+iU8VKWGzesiBusSaeInosrM6v8MQvsW3W9ApBCeUwNW6m+8sg==
   dependencies:
-    "@realm/common" "^0.1.4"
-    "@realm/network-transport" "^0.7.2"
+    abort-controller "^3.0.0"
+    node-fetch "^2.6.0"
+
+realm@^10.21.1:
+  version "10.21.1"
+  resolved "https://registry.yarnpkg.com/realm/-/realm-10.21.1.tgz#4432de92dae4d070c3203000a86a6421cf1a8cc6"
+  integrity sha512-I+QzOEw478LGPxgSLvF3YlsMCwRNe4d35uKB77tg2rARDYVtq4pW/XVfbvPrJnwPpgJR53stHmkspj0xvJgFUw==
+  dependencies:
+    "@realm.io/common" "^0.1.4"
     bindings "^1.5.0"
     bson "4.4.1"
     command-line-args "^5.1.1"
@@ -4871,6 +4869,7 @@ realm@^11.1.0:
     prebuild-install "^7.0.1"
     progress "^2.0.3"
     prop-types "^15.6.2"
+    realm-network-transport "^0.7.2"
     request "^2.88.0"
     stream-counter "^1.0.0"
     sync-request "^3.0.1"


### PR DESCRIPTION
Reverts noriyotcp/fragmemo#649

due to fail to build on https://github.com/noriyotcp/fragmemo/actions/runs/3399750519
