### PR TITLE
Bump realm from 10.23.0 to 11.1.0

### DIFF
--- a/main-process/db/db.ts
+++ b/main-process/db/db.ts
@@ -65,7 +65,7 @@ class DB extends Realm {
   }
 
   initFragment(snippetId: number): void {
-    const snippet: Snippet | undefined = this.objectForPrimaryKey(
+    const snippet: Snippet | null = this.objectForPrimaryKey(
       "Snippet",
       snippetId
     );
@@ -85,7 +85,7 @@ class DB extends Realm {
   }
 
   deleteFragment(fragmentId: number, nextActiveFragmentId?: number): void {
-    const fragment: Fragment | undefined = this.objectForPrimaryKey(
+    const fragment: Fragment | null = this.objectForPrimaryKey(
       "Fragment",
       fragmentId
     );
@@ -253,11 +253,10 @@ class DB extends Realm {
         )
       );
       // update _id of the latest one to 1
-      const latestOne: ActiveSnippetHistory | undefined =
-        this.objectForPrimaryKey(
-          "ActiveSnippetHistory",
-          this.currentMaxId("ActiveSnippetHistory")
-        );
+      const latestOne: ActiveSnippetHistory | null = this.objectForPrimaryKey(
+        "ActiveSnippetHistory",
+        this.currentMaxId("ActiveSnippetHistory")
+      );
       if (latestOne) {
         latestOne._id = 1;
       }

--- a/main-process/dbHandlers.ts
+++ b/main-process/dbHandlers.ts
@@ -11,7 +11,7 @@ const db = new DB(dataPath);
 
 export const setupStorage = (): void => {
   try {
-    if (db.empty) {
+    if (db.isEmpty) {
       db.initLanguage();
       db.initSnippet("");
     }

--- a/main-process/dbHandlers.ts
+++ b/main-process/dbHandlers.ts
@@ -21,7 +21,7 @@ export const setupStorage = (): void => {
   }
 };
 
-export const initSnippet = (): Snippet[] => {
+export const initSnippet = (): Snippet[] | Record<string, unknown> => {
   db.initSnippet("");
   return db.reverseSortBy("Snippet", "_id")[0].toJSON();
 };
@@ -30,7 +30,10 @@ export const initFragment = (snippetId: number): void => {
   db.initFragment(snippetId);
 };
 
-export const loadSnippets = (): Snippet[] | undefined => {
+export const loadSnippets = ():
+  | Snippet[]
+  | Record<string, unknown>[]
+  | undefined => {
   if (!db) return;
 
   try {
@@ -45,7 +48,9 @@ export const loadSnippets = (): Snippet[] | undefined => {
   }
 };
 
-export const getSnippet = (snippetId: number): Snippet | void => {
+export const getSnippet = (
+  snippetId: number
+): Snippet | Record<string, unknown> | void => {
   const snippet = db.objectForPrimaryKey("Snippet", snippetId);
   if (!snippet) return;
 
@@ -53,27 +58,36 @@ export const getSnippet = (snippetId: number): Snippet | void => {
   return snippet.toJSON();
 };
 
-export const getFragment = (fragmentId: number): Fragment | void => {
+export const getFragment = (
+  fragmentId: number
+): Fragment | Record<string, unknown> | void => {
   const fragment = db.objectForPrimaryKey("Fragment", fragmentId);
   if (!fragment) return;
 
   return fragment.toJSON();
 };
 
-export const getActiveFragment = (snippetId: number): Fragment => {
+export const getActiveFragment = (
+  snippetId: number
+): Fragment | Record<string, unknown> => {
   const activeFragment = db
     .objects("ActiveFragment")
     .filtered(`snippetId = ${snippetId}`)[0];
   return activeFragment.toJSON();
 };
 
-export const loadLanguages = (): Language[] | undefined => {
+export const loadLanguages = ():
+  | Language[]
+  | Record<string, unknown>[]
+  | undefined => {
   if (!db) return;
 
   return db.sortBy("Language", "_idx").toJSON();
 };
 
-export const loadFragments = (snippetId: number): Fragment[] => {
+export const loadFragments = (
+  snippetId: number
+): Fragment[] | Record<string, unknown>[] => {
   const fragments = db
     .objects("Fragment")
     .filtered(`snippet._id == ${snippetId}`) as unknown as Results<Fragment>;
@@ -127,7 +141,9 @@ export const newActiveSnippetHistory = (snippetId: number): void => {
   db.createActiveSnippetHistory(snippetId);
 };
 
-export const getLatestActiveSnippetHistory = (): JSON => {
+export const getLatestActiveSnippetHistory = ():
+  | JSON
+  | Record<string, unknown> => {
   return db.reverseSortBy("ActiveSnippetHistory", "_id")[0]?.toJSON();
 };
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fast-json-patch": "^3.1.1",
     "lit": "^2.4.0",
     "monaco-editor": "^0.34.0",
-    "realm": "^10.23.0",
+    "realm": "^11.1.0",
     "split.js": "^1.6.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,10 +932,19 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@realm.io/common@^0.1.4":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@realm.io/common/-/common-0.1.5.tgz#4285c8142d5024a0876318cdfd28f23ea98ebf4f"
-  integrity sha512-Y+UnICLvsPFpe2WOXWIdJUaV3G2qDocN8al/Yz13mYMkjODXHL4VhyfEKR2hvcAubv+7isdegEyYNdo3zQzbFA==
+"@realm/common@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@realm/common/-/common-0.1.4.tgz#48ff628a22b27c61ba886caff395909632240927"
+  integrity sha512-bKpIRZIQ4ykribFi0igCwuvf7P4+Ex2XYKqDw1JDe6sCGAaPMwhazooyM6h32fUjtXRTbdAWH2S9JH8Xh/LrqQ==
+
+"@realm/network-transport@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@realm/network-transport/-/network-transport-0.7.2.tgz#167b85fd4744b66d9e37d096e1e9e2720d7abd26"
+  integrity sha512-IZ6yd+mGOYvSMVEVFf/v5qtZOi8bk4ZBxoj25GNQFyeFKxOs1WH+z4IDZscMC2GhQ4hdmI3Sg+RUEphimtHupQ==
+  dependencies:
+    "@realm/common" "^0.1.4"
+    abort-controller "^3.0.0"
+    node-fetch "^2.6.0"
 
 "@sap-theming/theming-base-content@11.1.41":
   version "11.1.41"
@@ -4766,20 +4775,13 @@ readable-stream@^3.1.1, readable-stream@^3.4.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-realm-network-transport@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/realm-network-transport/-/realm-network-transport-0.7.2.tgz#382b965bf97a4132e0f8770f864d4a20d976be35"
-  integrity sha512-/5/YtZ5+ZIHIPgVFL6fRyx0/FRhmMaaF7L/h+iU8VKWGzesiBusSaeInosrM6v8MQvsW3W9ApBCeUwNW6m+8sg==
+realm@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/realm/-/realm-11.1.0.tgz#e1085eb045bb7155907cdf9960e89e2573cab94d"
+  integrity sha512-E3ZYw6jUXPcl1wGtZuGtqI2z2j/hoCeuP9Mq6KDVqLdfxXzJGciZpgF1szG8KXmqgHOslQboKJkIJmjGhGUvxg==
   dependencies:
-    abort-controller "^3.0.0"
-    node-fetch "^2.6.0"
-
-realm@^10.23.0:
-  version "10.23.0"
-  resolved "https://registry.yarnpkg.com/realm/-/realm-10.23.0.tgz#234f0e671c173f41bc6b0b560e11c9cff709b1c2"
-  integrity sha512-+a8bj50rg0Q5asOe/zjA7gNns9X0E/HlvXpRN0NVFK939EX8moY7bdVHZf+Dvt6HqC4UIzZxF8Aeqemat4HObA==
-  dependencies:
-    "@realm.io/common" "^0.1.4"
+    "@realm/common" "^0.1.4"
+    "@realm/network-transport" "^0.7.2"
     bindings "^1.5.0"
     bson "4.4.1"
     command-line-args "^5.1.1"
@@ -4792,7 +4794,6 @@ realm@^10.23.0:
     prebuild-install "^7.0.1"
     progress "^2.0.3"
     prop-types "^15.6.2"
-    realm-network-transport "^0.7.2"
     request "^2.88.0"
     stream-counter "^1.0.0"
     sync-request "^3.0.1"


### PR DESCRIPTION
- Bump realm form 10.23.0 to 11.1.0
- Fix return type of objectForPrimaryKey()
- Use Realm.isEmpty
- Fix return type of functions in dbHandlers.ts
