### PR TITLE
Update node engines semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": "18.x"
+    "node": "^18"
   },
   "dependencies": {
     "@ui5/webcomponents": "^1.11.0",


### PR DESCRIPTION
Dispate I installed Node.js version 18.15.0, it had still got an error:
``Attempted to run Node.js v18.0.0, but this version has not been installed. Install it with `proto install node 18.0.0`!``