### PR TITLE
feat: close database on app quit

### DIFF
--- a/electron/db/index.ts
+++ b/electron/db/index.ts
@@ -27,3 +27,8 @@ const sqlite = new Database(dbPath, { nativeBinding: bindingPath })
 export const db = drizzle(sqlite, { schema })
 
 console.log('Database initialized at:', dbPath)
+
+export function closeDatabase() {
+  sqlite.close()
+  console.log('Database closed')
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, Menu } from 'electron'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { db } from './db'
+import { closeDatabase, db } from './db'
 import { appState } from './db/schema'
 import { eq } from 'drizzle-orm'
 
@@ -177,6 +177,10 @@ app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
     createWindow()
   }
+})
+
+app.on('will-quit', () => {
+  closeDatabase()
 })
 
 app.whenReady().then(async () => {


### PR DESCRIPTION
## Summary
- Add `closeDatabase()` export to `electron/db/index.ts` to properly close the better-sqlite3 connection
- Add `will-quit` handler in `electron/main.ts` to call it on app shutdown
- Ensures clean database shutdown (best practice for better-sqlite3)

## Context
v1 had `will-quit` cleanup (Realm DB close + history reset). v2 was missing this. The history reset is no longer needed (replaced by `app_state` table), but DB close is still important.

## Test plan
- [x] Run `npm run dev`, create/edit snippets, quit the app — verify "Database closed" in console
- [x] Confirm data persists after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)