### PR TITLE
chore: ignore vite 8.x in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
         dependency-type: "development"
       production-dependencies:
         dependency-type: "production"
+    ignore:
+      # electron-vite 5.x requires vite ^5 || ^6 || ^7
+      - dependency-name: "vite"
+        versions: [">=8"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Add ignore rule for vite >=8 in dependabot.yml
- electron-vite 5.x requires `vite ^5 || ^6 || ^7`, so vite 8 causes ERESOLVE failure

Closes the failed dependabot PR #840. This ignore rule should be removed once electron-vite adds vite 8 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)