### PR TITLE
chore: ignore @vitejs/plugin-react >=6 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       # electron-vite 5.x requires vite ^5 || ^6 || ^7
       - dependency-name: "vite"
         versions: [">=8"]
+      # @vitejs/plugin-react 6.x requires vite ^8, blocked until electron-vite supports vite 8
+      - dependency-name: "@vitejs/plugin-react"
+        versions: [">=6"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- `@vitejs/plugin-react@6.x` は `vite@^8.0.0` を peer dependency として要求するが、`electron-vite@5.x` は `vite ^5 || ^6 || ^7` のみ対応
- この競合により PR #853 の CI が `ERESOLVE` で失敗していた
- `electron-vite` が vite 8 に対応するまで `@vitejs/plugin-react >=6` を dependabot の ignore リストに追加
- PR #853 はクローズ済み

## Test plan

- [ ] dependabot が次回 `@vitejs/plugin-react@6.x` を提案しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)