### PR TITLE
chore: refine dependabot groups and add eslint 10 ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,50 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      dev-dependencies:
-        dependency-type: "development"
       production-dependencies:
         dependency-type: "production"
+      # vite/electron 系は互いに peer dependency を持つため一緒に管理
+      dev-build:
+        patterns:
+          - "vite"
+          - "electron*"
+          - "@vitejs/*"
+          - "electron-vite"
+      # eslint 系は eslint-plugin-react-hooks との peer dependency 互換を一緒に確認
+      dev-tooling:
+        patterns:
+          - "eslint*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "globals"
+      # vitest/testing 系
+      dev-testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+          - "jsdom"
+      # 型定義（breaking change がほぼない）
+      dev-types:
+        patterns:
+          - "@types/*"
+      # 上記に含まれない残りの dev dependencies
+      dev-misc:
+        dependency-type: "development"
+        exclude-patterns:
+          - "vite"
+          - "electron*"
+          - "@vitejs/*"
+          - "electron-vite"
+          - "eslint*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "globals"
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+          - "jsdom"
+          - "@types/*"
     ignore:
       # electron-vite 5.x requires vite ^5 || ^6 || ^7
       - dependency-name: "vite"
@@ -16,6 +56,11 @@ updates:
       # @vitejs/plugin-react 6.x requires vite ^8, blocked until electron-vite supports vite 8
       - dependency-name: "@vitejs/plugin-react"
         versions: [">=6"]
+      # eslint-plugin-react-hooks 7.x supports eslint up to ^9 only
+      - dependency-name: "eslint"
+        versions: [">=10"]
+      - dependency-name: "@eslint/js"
+        versions: [">=10"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

- dev-dependencies を1つのグループにまとめていた設定を、peer dependency の関係ごとに細分化
- `eslint >=10` / `@eslint/js >=10` を ignore に追加（`eslint-plugin-react-hooks@7.x` が eslint 10 未対応のため）

## グループ構成

| グループ | 対象 | 理由 |
|---|---|---|
| `dev-build` | vite / electron-vite / @vitejs/* / electron* | 互いに peer dependency を持つため一緒に管理 |
| `dev-tooling` | eslint* / @eslint/* / typescript-eslint / globals | eslint-plugin-react-hooks との互換を一括確認 |
| `dev-testing` | vitest / @vitest/* / @testing-library/* / jsdom | テストスタック |
| `dev-types` | @types/* | breaking change がほぼなく独立して安全 |
| `dev-misc` | 上記以外の dev deps | 残り |

## ignore 追加の背景

- PR #853, #856 が `npm ci` で `ERESOLVE` 失敗を繰り返していた
- `eslint-plugin-react-hooks@7.0.1` の peer dependency は `eslint ^3〜^9` のみ対応
- `eslint` 10 対応の stable リリースが出るまで ignore

## 関連
- Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)