### PR TITLE
fix: prevent tabs bar from collapsing in flex layout

### DIFF
--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -297,7 +297,7 @@ export function Editor({ snippetId, onUpdate, settings }: { snippetId: string; o
       </div>
 
       {/* Tabs Bar */}
-      <div className="flex items-center bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 px-2 pt-2 gap-1 overflow-x-auto">
+      <div className="flex items-center bg-gray-50 dark:bg-gray-900 px-2 pt-2 gap-1 overflow-x-auto shrink-0">
         {fragments.map((fragment) => (
           <div
             key={fragment.id}
@@ -312,7 +312,7 @@ export function Editor({ snippetId, onUpdate, settings }: { snippetId: string; o
               className={`
                 group flex items-center gap-2 px-3 py-2 text-sm cursor-pointer border-t border-l border-r rounded-t-md select-none min-w-[120px] max-w-[200px] transition-colors
                 ${activeFragmentId === fragment.id
-                  ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 border-b-white dark:border-b-gray-800 -mb-px text-gray-800 dark:text-gray-100 font-medium'
+                  ? 'bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-800 dark:text-gray-100 font-medium'
                   : 'bg-gray-100 dark:bg-gray-900 border-transparent text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-800'}
               `}
           >


### PR DESCRIPTION
## Summary

- タブバーが Monaco Editor の下に隠れて見えなくなるバグを修正

## 根本原因

`overflow-x-auto` を持つ要素は CSS 仕様により `overflow-y: auto` も暗黙的に設定される。flex アイテムが `overflow: auto` を持つ場合、**自動最小サイズが 0** になる（CSS Flexbox 仕様）。

Monaco Editor が min-content の高さを要求すると flex アルゴリズムが空間を再配分し、min-size=0 のタブバーが潰れて高さ 0 になる。結果としてエディタツールバーがタブバーと同じ y 座標に配置され、視覚的に重なって見えていた。

## 修正内容

- タブバーコンテナに `shrink-0`（`flex-shrink: 0`）を追加 → flex アルゴリズムによる圧縮を防止
- `-mb-px` / `border-b-white` のシームレスタブトリックを削除（`overflow-x-auto` により `-mb-px` がクリップされるため機能していなかった）
- タブバーコンテナの `border-b` を削除（`bg-gray-900` vs `bg-gray-800` の色差で十分な視覚的区切りがある）

## Test plan

- [ ] タブバーが正しい位置に表示されること
- [ ] ウィンドウサイズを変更してもタブバーが潰れないこと
- [ ] アクティブタブ / 非アクティブタブの見た目が正常なこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)