### PR TITLE
chore: exclude CSS tooling from dependabot dev-misc group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,6 +49,10 @@ updates:
           - "@testing-library/*"
           - "jsdom"
           - "@types/*"
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "autoprefixer"
+          - "postcss"
     ignore:
       # electron-vite 5.x requires vite ^5 || ^6 || ^7
       - dependency-name: "vite"


### PR DESCRIPTION
## Summary

- `tailwindcss`, `@tailwindcss/*`, `autoprefixer`, `postcss` を `dev-misc` グループの `exclude-patterns` に追加
- これらは今後単独 PR として届くので、メジャーバンプが紛れ込まなくなる

## Background

Tailwind v3→v4 の破壊的変更（PostCSS プラグイン分離・CSS ディレクティブ変更等）が `dev-misc` グループに混ざってマージされ、ビルドが壊れた（#865 で対応）。CSS 基盤ツールは単独 PR で目立たせることで、メジャーアップ時に意図的に移行作業できるようにする。

## Test plan

- [x] dependabot.yml の YAML 構文確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)