### PR TITLE
fix: resolve react-hooks v7.1.1 rule violations

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -13,9 +13,10 @@ function App() {
   const [isRestored, setIsRestored] = useState(false)
 
   // Use ref to access latest search query in callbacks without dependency issues
-  // Direct assignment is safe during render (ref mutations don't trigger re-renders)
   const searchQueryRef = useRef(searchQuery)
-  searchQueryRef.current = searchQuery
+  useEffect(() => {
+    searchQueryRef.current = searchQuery
+  }, [searchQuery])
 
   const loadSnippets = useCallback(async () => {
     const data = await window.api.getSnippets()
@@ -63,10 +64,14 @@ function App() {
   }, [])
 
   useEffect(() => {
+    // Initial mount data load — setState runs once after async fetch, no cascading render
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadAppState()
   }, [loadAppState])
 
   useEffect(() => {
+    // Initial mount data load — setState runs once after async fetch, no cascading render
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     loadSnippets()
     loadSettings()
   }, [loadSnippets, loadSettings])
@@ -106,6 +111,16 @@ function App() {
     }
   }, [settings?.theme])
 
+  const handleCreateSnippet = useCallback(async () => {
+    const newSnippet = await window.api.createSnippet('Untitled Snippet')
+    await loadSnippets()
+    setActiveSnippetId(newSnippet.id)
+    // Persist immediately after state change (user action)
+    if (isRestored) {
+      window.api.updateAppState({ activeSnippetId: newSnippet.id })
+    }
+  }, [loadSnippets, isRestored])
+
   // Menu event handlers
   useEffect(() => {
     const unsubscribeNewSnippet = window.api.onMenuNewSnippet(() => {
@@ -120,7 +135,7 @@ function App() {
       unsubscribeNewSnippet()
       unsubscribeOpenSettings()
     }
-  }, [])
+  }, [handleCreateSnippet])
 
   // Keyboard shortcuts
   useEffect(() => {
@@ -157,14 +172,6 @@ function App() {
 
     return false
   })
-
-  const handleCreateSnippet = async () => {
-    const newSnippet = await window.api.createSnippet('Untitled Snippet')
-    await loadSnippets()
-    setActiveSnippetId(newSnippet.id)
-    // Persist immediately after state change (user action)
-    persistActiveSnippet(newSnippet.id)
-  }
 
   const handleDeleteSnippet = async (id: string) => {
     if (!confirm('Are you sure you want to delete this snippet?')) return

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -16,8 +16,9 @@ export function Editor({ snippetId, onUpdate, settings }: { snippetId: string; o
   const restoredIds = useRef<Set<string>>(new Set())
   const viewStatesRef = useRef<Record<string, unknown>>({}) // Store view states without re-rendering
 
-  // Sync activeFragmentId ref - direct assignment is safe during render
-  activeFragmentIdRef.current = activeFragmentId
+  useEffect(() => {
+    activeFragmentIdRef.current = activeFragmentId
+  }, [activeFragmentId])
 
   // Cleanup on unmount
   useEffect(() => {
@@ -108,8 +109,9 @@ export function Editor({ snippetId, onUpdate, settings }: { snippetId: string; o
     window.api.saveFragment(newFragments[index])
   }
 
-  // Update fragmentsRef - direct assignment is safe during render
-  fragmentsRef.current = fragments
+  useEffect(() => {
+    fragmentsRef.current = fragments
+  }, [fragments])
 
   const handleCreateFragment = async () => {
     const newFragment = {


### PR DESCRIPTION
## Summary

Fix pre-existing code violations on `main` so that dependabot PR #867 (`eslint-plugin-react-hooks` 7.0.1 → 7.1.1) can land without CI failures.

- **`react-hooks/refs`** (3 errors): Wrap `ref.current` assignments during render in `useEffect`.
  - `Editor.tsx`: `activeFragmentIdRef`, `fragmentsRef`
  - `App.tsx`: `searchQueryRef`
- **`react-hooks/immutability`** (1 error): Move `handleCreateSnippet` in `App.tsx` above its usage site, wrap in `useCallback`, and inline `persistActiveSnippet` logic to keep the callback's deps stable.
- **`react-hooks/set-state-in-effect`** (2 errors): Suppress with `eslint-disable-next-line` and a justification comment for initial-mount data loaders (`loadAppState`, `loadSnippets`). These fire `setState` once after an async fetch and do not cause cascading renders.

## Test plan

- [x] Installed `eslint-plugin-react-hooks@7.1.1` locally to reproduce the new-rule failures
- [x] After fixes, `npm run lint` reports 0 errors (the 2 remaining warnings are pre-existing `exhaustive-deps`)
- [x] `npm run build` succeeds
- [x] `npm run test:run` — all 10 tests pass
- [x] Reverted the package version so the actual bump lands via #867

Once this merges, #867 should auto-rebase and go green.