### PR TITLE
fix: resolve remaining react-hooks/exhaustive-deps warnings

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -85,13 +85,14 @@ function App() {
   }
 
   // Apply theme
+  const theme = settings?.theme
   useEffect(() => {
-    if (!settings) return
+    if (!theme) return
 
     const applyTheme = () => {
       const isDark =
-        settings.theme === 'dark' ||
-        (settings.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+        theme === 'dark' ||
+        (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
 
       if (isDark) {
         document.documentElement.classList.add('dark')
@@ -103,13 +104,13 @@ function App() {
     applyTheme()
 
     // Listen for system theme changes if in system mode
-    if (settings.theme === 'system') {
+    if (theme === 'system') {
       const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
       const handler = () => applyTheme()
       mediaQuery.addEventListener('change', handler)
       return () => mediaQuery.removeEventListener('change', handler)
     }
-  }, [settings?.theme])
+  }, [theme])
 
   const handleCreateSnippet = useCallback(async () => {
     const newSnippet = await window.api.createSnippet('Untitled Snippet')

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -113,7 +113,7 @@ export function Editor({ snippetId, onUpdate, settings }: { snippetId: string; o
     fragmentsRef.current = fragments
   }, [fragments])
 
-  const handleCreateFragment = async () => {
+  const handleCreateFragment = useCallback(async () => {
     const newFragment = {
       id: crypto.randomUUID(),
       snippetId,
@@ -134,7 +134,7 @@ export function Editor({ snippetId, onUpdate, settings }: { snippetId: string; o
 
     // Restore view state for new fragment (user action)
     restoreFragmentViewState(newFragment.id)
-  }
+  }, [snippetId, fragments, snippet, restoreFragmentViewState])
 
   const handleDeleteFragment = async (id: string, e: React.MouseEvent) => {
     e.stopPropagation()
@@ -232,7 +232,7 @@ export function Editor({ snippetId, onUpdate, settings }: { snippetId: string; o
       unsubscribeCloseTab()
       window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [activeFragmentId, fragments, snippet])
+  }, [activeFragmentId, fragments, snippet, handleCreateFragment, onUpdate, restoreFragmentViewState])
 
   const activeFragment = fragments.find(f => f.id === activeFragmentId)
 


### PR DESCRIPTION
## Summary

Clear the pre-existing `react-hooks/exhaustive-deps` warnings that were surfaced as GitHub Actions annotations on #869.

- `Editor.tsx`: Wrap `handleCreateFragment` in `useCallback` and add it (along with `onUpdate` and `restoreFragmentViewState`) to the menu/keyboard `useEffect` deps.
- `App.tsx`: Lift `settings?.theme` into a local const and reference it in the theme effect so `exhaustive-deps` is satisfied without pulling the whole `settings` object into deps.

Two "Unused eslint-disable directive" warnings for `react-hooks/set-state-in-effect` remain on `App.tsx`. They exist because the rule isn't present in the installed `eslint-plugin-react-hooks@7.0.1`, and will self-resolve once #867 lands (7.1.1).

## Test plan

- [x] `npm run lint` — 0 errors, 0 real warnings (only the two self-resolving unused-directive warnings)
- [x] `npm run build` succeeds
- [x] `npm run test:run` — all 10 tests pass