### PR TITLE
chore: migrate off deprecated externalizeDepsPlugin

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'path'
-import { defineConfig, externalizeDepsPlugin } from 'electron-vite'
+import { defineConfig } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -56,7 +56,7 @@ function bindingSqlite3(options: {
 
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin(), bindingSqlite3()],
+    plugins: [bindingSqlite3()],
     build: {
       rollupOptions: {
         input: {
@@ -66,7 +66,6 @@ export default defineConfig({
     }
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
     build: {
       rollupOptions: {
         input: {


### PR DESCRIPTION
## Summary

electron-vite 5 deprecates \`externalizeDepsPlugin\` in favor of the \`build.externalizeDeps\` config option, which is **enabled by default**. Drop the explicit plugin registration (and its import) — we don't need to set \`build.externalizeDeps: true\` explicitly since default is already true.

Ref: https://electron-vite.org/guide/migration (v5 migration guide)

## Test plan

- [x] \`npm run build\` succeeds, main / preload / renderer bundle sizes unchanged (main 8.11 kB, preload 1.54 kB, renderer 608.92 kB)
- [x] \`npm run lint\` — 0 issues
- [x] \`npm run test:run\` — all 10 tests pass