### PR TITLE
chore: scope node-abi override to @electron/rebuild

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8159,6 +8159,7 @@
       "version": "4.28.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.28.0.tgz",
       "integrity": "sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.6.3"
@@ -8171,6 +8172,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8689,6 +8691,30 @@
       },
       "bin": {
         "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -101,6 +101,8 @@
     "vitest": "^4.1.4"
   },
   "overrides": {
-    "node-abi": "^4.28.0"
+    "@electron/rebuild": {
+      "node-abi": "^4.28.0"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #874. The global \`node-abi\` override forced every transitive consumer onto 4.28.0. Narrow the override so only \`@electron/rebuild\`'s subtree resolves to \`^4.28.0\`; other chains (e.g. \`prebuild-install\`) fall back to their own ranges, which avoids future conflicts if an unrelated package needs a different major of \`node-abi\`.

```diff
 "overrides": {
-  "node-abi": "^4.28.0"
+  "@electron/rebuild": {
+    "node-abi": "^4.28.0"
+  }
 }
```

After the narrow override, \`prebuild-install\` gets its own \`node-abi@3.89.0\` nested copy (its natural range \`^3.3.0\`), while \`@electron/rebuild\` still uses \`node-abi@4.28.0\`.

## Test plan

- [x] Clean \`npm install\` — no conflicts
- [x] \`npm run build\` succeeds (electron-rebuild postinstall runs without the ABI error)
- [x] \`npm run lint\` — 0 issues
- [x] \`npm run test:run\` — all 10 tests pass