### PR TITLE
ci(build): rebuild better-sqlite3 before npm run build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
+      # vite-plugin-binding-sqlite3 needs build/Release/better_sqlite3.node,
+      # which better-sqlite3 only produces via build-release (npm ci alone is
+      # enough on v12, but v13 ships prebuilds/ instead)
+      - run: npm run rebuild
       - run: npm run lint
       - run: npm run test:run
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ npm run dev
 
 This project uses `better-sqlite3`, which includes a native Node addon. `npm install` automatically rebuilds it for Electron via the `postinstall` hook.
 
-If you see a `dlopen` architecture mismatch error (e.g. after running a cross-arch build like `npm run app:build:mac:x64` on an ARM Mac), rebuild the native module:
+Rebuild the native module explicitly when either of these happens:
 
 ```bash
 npm run rebuild
 ```
+
+- A `dlopen` architecture mismatch error, e.g. after a cross-arch build like `npm run app:build:mac:x64` on an ARM Mac.
+- `npm run build` fails with `[vite-plugin-binding-sqlite3] Cannot find .../build/Release/better_sqlite3.node`. The `postinstall` hook does not always leave that file behind — better-sqlite3 v13 ships `prebuilds/` instead — and only `npm run rebuild` produces it. The Build workflow runs this step for the same reason.
 
 ## License
 


### PR DESCRIPTION
## Why

The Build workflow runs `npm ci` and then goes straight to `npm run build`, relying on the `postinstall` electron-rebuild to leave `build/Release/better_sqlite3.node` behind for `vite-plugin-binding-sqlite3` (`electron.vite.config.ts`). That holds on better-sqlite3 v12, but not on v13: v13 ships `prebuilds/<platform>-<arch>.node` and leaves only `obj.target` stamps under `build/Release`, so the plugin throws before anything is compiled.

This blocks #913 (`better-sqlite3 ^12.10.0 -> ^13.0.1`). That PR's own CI is green because `lint-and-test.yml` never runs `npm run build` — the failure would only appear on `main` after merge.

## Evidence (local, macOS arm64)

| Branch | better-sqlite3 | `build/Release/better_sqlite3.node` after plain `npm ci` | `npm run build` |
| --- | --- | --- | --- |
| `main` | 12.11.1 | present | passes |
| #913 | 13.0.1 | absent (8 files under `prebuilds/` instead) | fails: `[vite-plugin-binding-sqlite3] Cannot find .../build/Release/better_sqlite3.node` |

Inserting `npm run rebuild` before `npm run build` makes the #913 branch build successfully. On the current v12 `main` the added step is redundant but harmless: it exits 0 and the build still passes.

## Changes

- `.github/workflows/build.yml`: run `npm run rebuild` right after `npm ci`.
- `README.md`: document the `Cannot find .../better_sqlite3.node` case in the existing "Native module rebuild" section, alongside the existing `dlopen` arch-mismatch case.

## Follow-up, not in this PR

`create-release.yml` has the same gap — it runs `npm ci`, then `npx electron-rebuild --arch <arch>`, then `npm run app:build:mac:<arch>`, which invokes the same vite plugin. Dropping `npm run rebuild` in there as-is would lose the cross-arch target, because `scripts/rebuild.cjs` does not accept `--arch`; fixing it properly needs an arch argument threaded through that script. Worth doing before the next release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)