### PR TITLE
ci(release): build the native binding via npm run rebuild

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,8 +26,10 @@ jobs:
           node-version: 22.x
           cache: "npm"
       - run: npm ci
+      # electron-rebuild does not leave build/Release/better_sqlite3.node behind
+      # on better-sqlite3 v13, and vite-plugin-binding-sqlite3 needs it
       - name: Rebuild native modules for ${{ matrix.arch }}
-        run: npx electron-rebuild --arch ${{ matrix.arch }}
+        run: npm run rebuild -- --arch ${{ matrix.arch }}
       - name: Build app for Mac (${{ matrix.arch }})
         run: npm run app:build:mac:${{ matrix.arch }}
       - name: Upload artifacts

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Rebuild the native module explicitly when either of these happens:
 npm run rebuild
 ```
 
-- A `dlopen` architecture mismatch error, e.g. after a cross-arch build like `npm run app:build:mac:x64` on an ARM Mac.
+- A `dlopen` architecture mismatch error, e.g. after a cross-arch build like `npm run app:build:mac:x64` on an ARM Mac. Pass `-- --arch x64` (or `arm64`) to build for a specific architecture; without it the host architecture is used.
 - `npm run build` fails with `[vite-plugin-binding-sqlite3] Cannot find .../build/Release/better_sqlite3.node`. The `postinstall` hook does not always leave that file behind — better-sqlite3 v13 ships `prebuilds/` instead — and only `npm run rebuild` produces it. The Build workflow runs this step for the same reason.
 
 ## License

--- a/scripts/rebuild.cjs
+++ b/scripts/rebuild.cjs
@@ -17,6 +17,21 @@ const better_sqlite3_root = path.posix.join(
   'node_modules/better-sqlite3'
 );
 
+// npm run rebuild -- --arch x64 (or --arch=x64) cross-compiles for another arch
+const args = process.argv.slice(2);
+const archIndex = args.findIndex((arg) => arg === '--arch' || arg.startsWith('--arch='));
+const arch =
+  archIndex === -1
+    ? process.arch
+    : args[archIndex].includes('=')
+      ? args[archIndex].split('=')[1]
+      : args[archIndex + 1];
+
+if (!arch) {
+  console.error('❌ --arch was given without a value.');
+  process.exit(1);
+}
+
 const cp = child.spawn(
   process.platform === 'win32' ? 'npm.cmd' : 'npm',
   [
@@ -24,6 +39,7 @@ const cp = child.spawn(
     'build-release',
     `--target=${electronVersion}`,
     '--dist-url=https://electronjs.org/headers',
+    `--arch=${arch}`,
   ],
   {
     cwd: better_sqlite3_root,


### PR DESCRIPTION
## Why

Follow-up to #920, which fixed the same gap in `build.yml`.

The release job runs `npx electron-rebuild --arch <arch>` and then `npm run app:build:mac:<arch>`. That second step goes through electron-vite, so it hits `vite-plugin-binding-sqlite3`, which requires `build/Release/better_sqlite3.node`. electron-rebuild does not leave that file behind on better-sqlite3 v13 (it ships `prebuilds/<platform>-<arch>.node` instead), so once #913 lands the release build fails exactly the way `main`'s Build workflow did before #920.

`npm run rebuild` does produce that file, but `scripts/rebuild.cjs` always built for the host architecture — swapping it in as-is would have silently dropped the cross-arch target the matrix needs, and an x64 dmg containing an arm64 binding only fails at runtime on a user's machine.

## Changes

- `scripts/rebuild.cjs`: accept `--arch <arch>` / `--arch=<arch>` and pass it through to node-gyp; default to `process.arch`; exit 1 if `--arch` is given without a value.
- `.github/workflows/create-release.yml`: use `npm run rebuild -- --arch ${{ matrix.arch }}` in place of `npx electron-rebuild --arch`.
- `README.md`: document the `-- --arch` form in the existing "Native module rebuild" section.

## Verification (local, arm64 Mac, arch read with `lipo -archs`)

| Invocation | Resulting binding |
| --- | --- |
| `npm run rebuild` | arm64 |
| `npm run rebuild -- --arch x64` | x86_64 |
| `npm run rebuild -- --arch=x64` | x86_64 |
| `npm run rebuild -- --arch` | no build, exits 1 with an error |

`npm run build` and `npm run lint` both pass afterwards with the host-arch binding restored.

## Not verified by this PR

`create-release.yml` only fires on a `v*` tag or `workflow_dispatch`, so merging this proves nothing about the release path — CI here runs `lint-and-test` only. Worth a manual `workflow_dispatch` run after merge to confirm both dmgs build; the release it creates is a draft, so a trial run publishes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)