### PR TITLE
chore(dependabot): keep majors out of grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      # major bump は breaking change のため standalone PR 化する
       production-dependencies:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
       # vite/electron 系は互いに peer dependency を持つため一緒に管理
       # ただし major bump は breaking change のため standalone PR 化する
       dev-build:
@@ -32,13 +36,20 @@ updates:
           - "@vitest/*"
           - "@testing-library/*"
           - "jsdom"
+        update-types:
+          - "minor"
+          - "patch"
       # 型定義（breaking change がほぼない）
       dev-types:
         patterns:
           - "@types/*"
       # 上記に含まれない残りの dev dependencies
+      # major bump は typescript のように影響範囲が広いため standalone PR 化する
       dev-misc:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
         exclude-patterns:
           - "vite"
           - "electron*"


### PR DESCRIPTION
## Why

Only `dev-build` restricted its group to minor and patch, so majors kept arriving bundled with unrelated bumps. Three examples from a single triage session:

- **#910** paired the TypeScript 6 -> 7 major (the Go/tsgo rewrite) with an `@electron/rebuild` minor via `dev-misc`. That PR cannot install at all — typescript-eslint peers on `typescript >=4.8.4 <6.1.0` and no released version supports TS 7 — so `npm ci` fails before lint, test or build run, and the harmless half is stuck behind the blocked half.
- **#913** carried the better-sqlite3 12 -> 13 major via `production-dependencies`. v13 moved the native binding to `prebuilds/`, which broke `npm run build`; the group's three harmless bumps (monaco, react, react-dom) hid a change that needed #920 and #921 to land first. Its own CI was green because `lint-and-test.yml` never runs `npm run build`.
- **#915** carried the `@testing-library/jest-dom` 6 -> 7 major via `dev-testing`.

## Changes

`update-types: [minor, patch]` added to `production-dependencies`, `dev-testing` and `dev-misc`, matching what `dev-build` already does. Majors now arrive as standalone PRs and can be reviewed on their own merits.

| Group | `update-types` |
| --- | --- |
| production-dependencies | `[minor, patch]` (new) |
| dev-build | `[minor, patch]` (unchanged) |
| dev-tooling | none |
| dev-testing | `[minor, patch]` (new) |
| dev-types | none |
| dev-misc | `[minor, patch]` (new) |

Two groups are deliberately left alone:

- `dev-types` — `@types/*` majors track the runtime package's version and carry no separate breaking change of their own.
- `dev-tooling` — the `ignore` block already blocks `eslint` and `@eslint/js` at `>=10`, which covers the main major path. A `typescript-eslint` major would still be grouped; say so if that should be restricted too.

## Note

This does not retroactively split #910. Dependabot regenerates the group on its next weekly run, or right away if #910 is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)