### PR TITLE
fix(release): package one architecture per build

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ npm run rebuild
 ```
 
 - A `dlopen` architecture mismatch error, e.g. after a cross-arch build like `npm run app:build:mac:x64` on an ARM Mac. Pass `-- --arch x64` (or `arm64`) to build for a specific architecture; without it the host architecture is used.
-- `npm run build` fails with `[vite-plugin-binding-sqlite3] Cannot find .../build/Release/better_sqlite3.node`. The `postinstall` hook does not always leave that file behind — better-sqlite3 v13 ships `prebuilds/` instead — and only `npm run rebuild` produces it. The Build workflow runs this step for the same reason.
+- `npm run build` fails with `[vite-plugin-binding-sqlite3] Cannot find .../build/Release/better_sqlite3.node`. The `postinstall` hook does not always leave that file behind — better-sqlite3 v13 ships `prebuilds/` instead — and only `npm run rebuild` produces it. The Build workflow runs this step for the same reason. `electron-builder` also clears that file while packaging, so a second `app:build` in a row needs another `npm run rebuild`.
+
+Each `app:build:mac:*` script packages one architecture, and the binding it ships is whatever `npm run rebuild` last produced. Build the matching binding first:
+
+```bash
+npm run rebuild -- --arch arm64 && npm run app:build:mac:arm64
+npm run rebuild -- --arch x64 && npm run app:build:mac:x64
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -37,11 +37,7 @@
       "icon": "icons/icon.png",
       "target": [
         {
-          "target": "dmg",
-          "arch": [
-            "x64",
-            "arm64"
-          ]
+          "target": "dmg"
         }
       ]
     },


### PR DESCRIPTION
## The bug

`build.mac.target` listed both `x64` and `arm64`, so electron-builder produced **both** bundles regardless of the `--x64` / `--arm64` flag the `app:build:mac:*` script passes. Only one native binding exists at a time — `vite-plugin-binding-sqlite3` copies it into `out/native` while `electron-vite build` runs, before electron-builder starts — so both bundles get the same binding and one of them is always wrong for its architecture.

An arm64 dmg carrying an x86_64 `better_sqlite3.node` fails at runtime on the user's machine, not during the build, which is why CI never caught it.

In the release matrix this compounds: both legs write the same two dmg filenames (`fragmemo-2.0.0.dmg`, `fragmemo-2.0.0-arm64.dmg`), each leg producing one good and one broken copy, and `create-release` merges every artifact into a single directory with `merge-multiple: true` — so which copy survives comes down to arrival order.

This is pre-existing behaviour, not something #921 introduced; the old `npx electron-rebuild --arch <arch>` step had the same single-binding problem.

## Measured on an arm64 Mac

Each bundle's binding and Electron Framework read with `lipo -archs`:

| Config | Command | Bundles built | `release/mac` | `release/mac-arm64` |
| --- | --- | --- | --- | --- |
| before | `app:build:mac:x64` | both | binding x86_64 / fw x86_64 — ok | binding **x86_64** / fw arm64 — broken |
| before | `app:build:mac:arm64` | both | binding **arm64** / fw x86_64 — broken | binding arm64 / fw arm64 — ok |
| after | `app:build:mac:x64` | `mac` only | binding x86_64 / fw x86_64 — ok | not built |
| after | `app:build:mac:arm64` | `mac-arm64` only | not built | binding arm64 / fw arm64 — ok |

## Changes

- `package.json`: drop the `arch` list from `build.mac.target` so the `--x64` / `--arm64` CLI flag decides, which is what the release matrix already expresses.
- `README.md`: document that each `app:build:mac:*` packages one architecture and needs a matching `npm run rebuild -- --arch <arch>` first, and that electron-builder clears the binding while packaging, so back-to-back local builds need another rebuild.

## Not verified

Whether any already-published dmg carries a mismatched binding — this PR only establishes what the current build pipeline produces. Checking that would mean downloading the released artifacts and reading their bindings.

`create-release.yml` still only runs on a `v*` tag or `workflow_dispatch`, so this fix is exercised for real at the next release build. Note that a `workflow_dispatch` run on a branch cannot reach a green finish: `ncipollo/release-action` requires a tag from the ref or the `tag` input, and this workflow passes neither, so the `create-release` job fails by design there while `build-macos` still shows whether packaging worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)