### PR TITLE
chore(deps): raise the node-abi override for Electron 43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7168,9 +7168,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.28.0.tgz",
-      "integrity": "sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+      "integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
   },
   "overrides": {
     "@electron/rebuild": {
-      "node-abi": "^4.28.0"
+      "node-abi": "^4.32.0"
     }
   }
 }


### PR DESCRIPTION
## Why

`overrides["@electron/rebuild"]["node-abi"]` exists because @electron/rebuild's own node-abi range lags behind new Electron majors. It was written as `^4.28.0` while Electron 42 was current, and the lockfile pinned exactly 4.28.0 — whose ABI registry stops at Electron 42.

So #925 (electron 42.4.1 -> 43.2.0) fails in CI at `npm ci`, before eslint or vitest run:

```
Could not detect abi for version 43.2.0 and runtime electron.
  Updating "node-abi" might help solve this issue if it is a new release of electron
    at getAbi (node_modules/node-abi/index.js:32:9)
    at get ABI (node_modules/@electron/rebuild/lib/rebuild.js:79:31)
npm error command sh -c npx electron-rebuild
```

Merging #923 (@electron/rebuild 4.0.4 -> 4.2.0) did not help: that bump leaves the node-abi lock entry untouched.

## Verified by calling node-abi directly

| node-abi | electron 42.4.1 | electron 43.2.0 |
| --- | --- | --- |
| 4.28.0 (what the lock pinned) | 146 | throws |
| 4.31.0 | 146 | 148 |
| 4.33.0 (what the lock now resolves) | 146 | 148 |

4.31.0 is the first release carrying the Electron 43 entry.

## Changes

- `package.json`: `node-abi` override `^4.28.0` -> `^4.32.0`.
- `package-lock.json`: node-abi 4.28.0 -> 4.33.0 (three lines: version, resolved, integrity).

The caret range already permitted a newer node-abi — the **lockfile** was the actual blocker, since CI uses `npm ci` and honors it verbatim. Raising the range text is what moves the lock, and it documents which node-abi Electron 43 needs.

## Verification

Run on the current Electron 42 tree, so this change is safe to land before #925: `npm ci`, `npm run rebuild`, `npm run lint`, `npm run test:run` and `npm run build` all pass, and the installed node-abi resolves both Electron 42 (146) and 43 (148).

This does not bump Electron itself. #925 still needs a rebase after this lands, and its own risk — better-sqlite3 13.0.1 compiled against Electron 43's Node 24 headers — is not covered by PR CI, which never runs `npm run rebuild` or `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)