### PR TITLE
ci(release): skip the release job when the ref has no tag

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -42,6 +42,9 @@ jobs:
 
   create-release:
     needs: build-macos
+    # release-action needs a tag from the ref; a workflow_dispatch on a branch
+    # has none, so skip this job and let such runs verify packaging only
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Why

`create-release.yml` accepts `workflow_dispatch`, which is the only way to check that packaging still works without cutting a release — otherwise the workflow runs on `v*` tags only, and it had not run since v2.0.0 in April.

But on a branch dispatch the release step always fails. `ncipollo/release-action` takes the tag from the ref or the `tag` input, and this workflow passes neither.

Confirmed today on run [30156542004](https://github.com/noriyotcp/fragmemo/actions/runs/30156542004) (dispatch on `main`):

| Job | Result |
| --- | --- |
| `build-macos (arm64)` | success |
| `build-macos (x64)` | success |
| `create-release` | failure — `Error undefined: No tag found in ref or input!` |

Packaging was fine, and the two artifacts came out one per architecture (153.8 MB arm64, 155.8 MB x64) as #926 intended — but the run still reads red, which makes this check unpleasant to use and easy to misread later.

## Change

Guard the `create-release` job with `if: startsWith(github.ref, 'refs/tags/')`.

- Branch dispatch: the job is skipped, so the run finishes green and serves as a packaging check.
- Tag push (`v*`): unchanged, the job runs as before.
- Dispatch against a tag ref also still creates the release, since `github.ref` is `refs/tags/<tag>` in that case.

## Verification

The YAML parses and the guard lands on the `create-release` job only; `build-macos` steps and the workflow triggers are untouched. The behaviour itself is only observable on a dispatch after this merges — worth one more dispatch run then, which should come out green with `create-release` skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)